### PR TITLE
feat: standardize mobile touch target sizing

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -20,6 +20,7 @@
   --shadow-lg: 0 8px 32px rgba(0, 212, 255, 0.15);
   --shadow-hover: 0 12px 40px rgba(0, 212, 255, 0.2);
   --border-glow: 0 0 20px rgba(0, 212, 255, 0.3);
+  --touch-target: 44px;
 }
 
 body {
@@ -111,8 +112,8 @@ header {
   padding: 0.75rem;
   border-radius: var(--radius);
   transition: all 0.3s ease;
-  min-width: 44px;
-  min-height: 44px;
+  min-width: var(--touch-target);
+  min-height: var(--touch-target);
   -webkit-tap-highlight-color: transparent;
   z-index: 300;
 }
@@ -188,6 +189,7 @@ nav {
   color: var(--color-fg);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  min-height: var(--touch-target);
 }
 
 .mobile-nav nav a:hover,
@@ -563,6 +565,8 @@ nav a.active {
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  min-width: var(--touch-target);
+  min-height: var(--touch-target);
 }
 
 .cta-button:hover {


### PR DESCRIPTION
## Summary
- centralize minimum touch target size via `--touch-target` CSS variable
- apply consistent mobile tap area to navigation links and call-to-action buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run html:lint` *(fails: tag-pair errors in `public/about.html`)*

------
https://chatgpt.com/codex/tasks/task_e_6890d69551b883239fcbe4d0d907d176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized the minimum size of interactive elements across the site for improved touch accessibility by introducing a new CSS variable for touch targets.
  * Updated buttons, navigation links, and menu toggles to use the new consistent sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->