### PR TITLE
docs: cross-link repository guides

### DIFF
--- a/DEPLOY-CHECKLIST.md
+++ b/DEPLOY-CHECKLIST.md
@@ -69,6 +69,11 @@ curl -I https://www.macrosight.net/home.html | grep -i "strict-transport-securit
 2. Test in Wix Preview
 3. No changes needed to static files
 
+## Related Documentation
+- [TESTING-GUIDE.md](TESTING-GUIDE.md) – step-by-step commands to verify headers and pages
+- [DNS-FIX-GUIDE.md](DNS-FIX-GUIDE.md) – instructions for pointing the domain to Netlify
+- [WIX-FIX-SUMMARY.md](WIX-FIX-SUMMARY.md) – background on the Wix module relocation
+
 ---
-**Generated**: $(date)  
+**Generated**: $(date)
 **Next Review**: Every major deployment

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 This static site implements a hybrid architecture that supports both standalone HTML pages and Wix-Velo iframe integration through postMessage communication.
 
+## Documentation
+
+- [AUDIT-REPORT.md](AUDIT-REPORT.md) – deployment audit and fix history
+- [CURRENT-STATUS.md](CURRENT-STATUS.md) – current deployment snapshot
+- [DNS-FIX-GUIDE.md](DNS-FIX-GUIDE.md) – steps to route the domain to Netlify
+- [DEPLOY-CHECKLIST.md](DEPLOY-CHECKLIST.md) – pre- and post-deployment tasks
+- [TESTING-GUIDE.md](TESTING-GUIDE.md) – commands for verifying headers and pages
+- [WIX-FIX-SUMMARY.md](WIX-FIX-SUMMARY.md) – details of the Wix module migration
+- Directory guides: [src/pages/README.md](src/pages/README.md), [src/public/README.md](src/public/README.md), [src/backend/README.md](src/backend/README.md)
+
 ## 🏗 **DEPLOYMENT STATUS**
 - **Static Site**: ✅ Deployed on Netlify (`public/` folder)
 - **Wix Integration**: ✅ Velo code in `src/` folder  

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,14 +1,6 @@
 # The Backend Code Folder
 
-## SEO & Launch Files
-
-This site includes:
-- `/robots.txt` (allows all, points to sitemap)
-- `/sitemap.xml` (lists all public pages)
-
-Both are in `/public` and will be live at the root of your deployed site for search engines and best practice.
-
-This folder contains the backend code files for your site. These files correspond to the ones found in the [**Backend**](https://support.wix.com/en/article/velo-working-with-the-velo-sidebar#backend) section of the **Public & Backend** 
+This folder contains the backend code files for your site. For details about site-wide SEO assets, refer to the repository [README](../../README.md). These files correspond to the ones found in the [**Backend**](https://support.wix.com/en/article/velo-working-with-the-velo-sidebar#backend) section of the **Public & Backend**
 ![image](https://user-images.githubusercontent.com/89579857/184862813-e55cdd98-b723-4d64-b73c-593eb9af21c7.png) tab in the Velo sidebar. Add the following files to this folder to include them in your site:
 + [**Web Modules:**](https://support.wix.com/en/article/velo-web-modules-calling-backend-code-from-the-frontend)  
   These are files that allow you to expose functions in your site's backend that you can run in your frontend code. These files require a `.jsw` file extension.

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -1,12 +1,6 @@
 # Usage with Wix Velo
 
-## SEO & Launch Files
-
-This site includes:
-- `/robots.txt` (allows all, points to sitemap)
-- `/sitemap.xml` (lists all public pages)
-
-Both are in `/public` and will be live at the root of your deployed site for search engines and best practice.
+For site-wide SEO files like `robots.txt` and `sitemap.xml`, see the repository [README](../../README.md).
 
 All page scripts should import global styles like this for Wix/Velo compatibility:
 

--- a/src/public/README.md
+++ b/src/public/README.md
@@ -1,14 +1,6 @@
 # Public Directory — Global Styling for MacroSight.net
 
-## SEO & Launch Files
-
-This site includes:
-- `/robots.txt` (allows all, points to sitemap)
-- `/sitemap.xml` (lists all public pages)
-
-Both are in `/public` and will be live at the root of your deployed site for search engines and best practice.
-
-This `/public` directory contains globally scoped utility logic that can be reused across the entire MacroSight site.
+This directory contains globally scoped web modules that can be reused across the entire MacroSight site. For site-wide SEO files such as `robots.txt` or `sitemap.xml`, see the repository [README](../../README.md).
 
 ---
 


### PR DESCRIPTION
## Summary
- centralize documentation links in root README
- link related guides from deployment checklist
- trim redundant SEO notes in directory READMEs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `./quick-test.sh` *(fails: incorrect headers and 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_6890de9a57d083238ee561c074db508c

## Summary by Sourcery

Improve discoverability and organization of repository documentation by centralizing links, reducing duplication, and enhancing cross-references between guides.

Documentation:
- Centralize and cross-link all major repository documentation in the root README.
- Add related documentation links to the deployment checklist for easier navigation.
- Trim redundant SEO notes from directory-level READMEs and reference the root README instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new "Documentation" sections in the main and deployment README files, providing easier access to related guides and resources.
  * Simplified and unified references to SEO and launch files across backend, pages, and public directory READMEs, directing users to the main repository README for details.
  * Enhanced overall documentation structure for improved navigation and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->