### PR TITLE
Improve mobile nav display on tablets

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -634,6 +634,22 @@ footer {
 }
 
 /* Responsive Design */
+
+/* Tablet and smaller navigation */
+@media (max-width: 768px) {
+  .desktop-nav {
+    display: none;
+  }
+
+  .mobile-menu-toggle {
+    display: block;
+  }
+
+  .mobile-nav {
+    display: block;
+  }
+}
+
 /* Mobile-First Responsive Design */
 @media (max-width: 480px) {
   body {


### PR DESCRIPTION
## Summary
- show hamburger menu and mobile nav up to 768px width so navigation works on tablets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890e67b835c8323b83cfb33c9236c02

## Summary by Sourcery

Enhancements:
- Display mobile navigation and hamburger menu on tablet screens up to 768px by hiding the desktop nav and showing the mobile menu toggle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved navigation responsiveness for tablet and smaller screens by updating styles to display mobile navigation elements and hide desktop navigation as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->