### PR TITLE
fix: align mobile CTA buttons

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -550,7 +550,9 @@ nav a.active {
 }
 
 .cta-button {
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
   margin: 0.5rem;
   padding: 0.75rem 1.5rem;
   border-radius: var(--radius);
@@ -567,6 +569,7 @@ nav a.active {
   letter-spacing: 0.05em;
   min-width: var(--touch-target);
   min-height: var(--touch-target);
+  text-align: center;
 }
 
 .cta-button:hover {
@@ -722,12 +725,21 @@ footer {
     gap: 0.75rem;
     align-items: stretch;
   }
-  
+
   .cta-button {
+    display: flex;
+    width: 100%;
+    margin: 0;
     padding: 0.875rem 1.5rem;
     font-size: 0.9rem;
-    width: 100%;
+    justify-content: center;
+    align-items: center;
     text-align: center;
+    box-sizing: border-box;
+  }
+
+  .cta-button.secondary {
+    width: 100%;
   }
   
   .expertise-grid {


### PR DESCRIPTION
## Summary
- ensure CTA buttons center their content for better touch targets
- expand primary and secondary CTA buttons to full width on small screens
- remove mobile overflow by letting flex gap manage spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890f28589c88323abefb6489f899866

## Summary by Sourcery

Align and improve mobile CTA buttons by centering content and expanding them to full width with proper spacing

Bug Fixes:
- Remove mobile overflow by letting flex gap manage spacing

Enhancements:
- Switch CTA buttons to flex layout with centered content, box-sizing, and text alignment for improved touch targets
- Expand primary and secondary CTA buttons to full width on small screens with adjusted margins and rely on flex gap for consistent spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and alignment of call-to-action buttons for consistent centering and sizing across the site, including in the footer and on mobile devices. Buttons now use flexbox for better visual consistency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->