### PR TITLE
fix: improve mobile header navigation

### DIFF
--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 function toggleMobileMenu() {
   const mobileNav = document.getElementById("mobile-nav");
   const menuIcon = document.getElementById("menu-icon");
@@ -11,7 +12,7 @@ function toggleMobileMenu() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+function initMobileNav() {
   document.querySelectorAll(".mobile-nav a").forEach((link) => {
     link.addEventListener("click", () => {
       setTimeout(() => {
@@ -45,4 +46,10 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     }
   });
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initMobileNav);
+} else {
+  initMobileNav();
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -150,6 +150,7 @@ nav {
   box-shadow: var(--shadow-lg);
   z-index: 200;
   transition: opacity 0.3s ease, visibility 0.3s ease;
+  pointer-events: none;
 }
 
 .mobile-nav.active {
@@ -157,6 +158,7 @@ nav {
   animation: slideDown 0.3s ease;
   visibility: visible;
   opacity: 1;
+  pointer-events: auto;
 }
 
 @keyframes slideDown {


### PR DESCRIPTION
## Summary
- ensure mobile menu scripts initialize even if DOM has already loaded
- prevent hidden mobile nav overlay from intercepting taps

## Testing
- `npx eslint public/mobile-nav.js --no-ignore`
- `npm run lint`
- `bash quick-test.sh` *(fails: page load issue (HTTP 403); HSTS/CSP missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890f62e0d108323b1525e58a61fd4d1

## Summary by Sourcery

Ensure mobile header navigation scripts initialize correctly regardless of DOM load state and disable hidden menu overlay from intercepting taps.

Bug Fixes:
- Set pointer-events to none on hidden mobile nav and auto when active to prevent hidden overlay from intercepting taps

Enhancements:
- Extract mobile nav initialization into initMobileNav and invoke it immediately if the DOM is already loaded