### PR TITLE
Improve mobile nav dropdown behavior

### DIFF
--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -2,10 +2,13 @@
 function toggleMobileMenu() {
   const mobileNav = document.getElementById("mobile-nav");
   const menuIcon = document.getElementById("menu-icon");
-  if (mobileNav && menuIcon) {
+  const toggleBtn = document.querySelector(".mobile-menu-toggle");
+  if (mobileNav && menuIcon && toggleBtn) {
     mobileNav.classList.toggle("active");
     const isActive = mobileNav.classList.contains("active");
     menuIcon.textContent = isActive ? "✕" : "☰";
+    toggleBtn.setAttribute("aria-expanded", isActive);
+    document.body.style.overflow = isActive ? "hidden" : "";
     document.dispatchEvent(
       new CustomEvent("mobile-menu-toggle", { detail: { isActive } }),
     );
@@ -13,19 +16,18 @@ function toggleMobileMenu() {
 }
 
 function initMobileNav() {
+  const toggleBtn = document.querySelector(".mobile-menu-toggle");
+  if (toggleBtn) {
+    toggleBtn.setAttribute("aria-controls", "mobile-nav");
+    toggleBtn.setAttribute("aria-expanded", "false");
+  }
+
   document.querySelectorAll(".mobile-nav a").forEach((link) => {
     link.addEventListener("click", () => {
       setTimeout(() => {
         const mobileNav = document.getElementById("mobile-nav");
-        const menuIcon = document.getElementById("menu-icon");
-        if (mobileNav && menuIcon) {
-          mobileNav.classList.remove("active");
-          menuIcon.textContent = "☰";
-          document.dispatchEvent(
-            new CustomEvent("mobile-menu-toggle", {
-              detail: { isActive: false },
-            }),
-          );
+        if (mobileNav && mobileNav.classList.contains("active")) {
+          toggleMobileMenu();
         }
       }, 100);
     });
@@ -39,11 +41,18 @@ function initMobileNav() {
       mobileNav.classList.contains("active") &&
       !header.contains(e.target)
     ) {
-      mobileNav.classList.remove("active");
-      document.getElementById("menu-icon").textContent = "☰";
-      document.dispatchEvent(
-        new CustomEvent("mobile-menu-toggle", { detail: { isActive: false } }),
-      );
+      toggleMobileMenu();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    const mobileNav = document.getElementById("mobile-nav");
+    if (
+      e.key === "Escape" &&
+      mobileNav &&
+      mobileNav.classList.contains("active")
+    ) {
+      toggleMobileMenu();
     }
   });
 }


### PR DESCRIPTION
## Summary
- ensure mobile menu toggle updates `aria-expanded` and locks background scroll
- add ARIA metadata, outside click, and Escape key handling for dropdown closing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6890f8e363dc83238ff5927c85ff01bd

## Summary by Sourcery

Enhance mobile navigation dropdown by improving accessibility, locking background scroll on open, and adding unified close behavior via outside clicks and the Escape key.

New Features:
- Lock background scroll when the mobile menu is opened
- Add Escape key listener to close the mobile menu

Enhancements:
- Add ARIA attributes (aria-controls, aria-expanded) to the mobile menu toggle button
- Refactor link click and outside-click handlers to use the central toggleMobileMenu function for consistent behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for closing the mobile menu with the Escape key.
  * Improved accessibility by updating `aria-expanded` and `aria-controls` attributes on the mobile menu toggle button.

* **Refactor**
  * Unified menu state handling for more consistent behavior when opening and closing the mobile menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->