### PR TITLE
Ensure mobile header links redirect

### DIFF
--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -14,7 +14,9 @@ function toggleMobileMenu() {
 
 function initMobileNav() {
   document.querySelectorAll(".mobile-nav a").forEach((link) => {
-    link.addEventListener("click", () => {
+    link.addEventListener("click", (e) => {
+      const target = link.getAttribute("href");
+      e.preventDefault();
       setTimeout(() => {
         const mobileNav = document.getElementById("mobile-nav");
         const menuIcon = document.getElementById("menu-icon");
@@ -26,6 +28,9 @@ function initMobileNav() {
               detail: { isActive: false },
             }),
           );
+        }
+        if (target) {
+          window.location.href = target;
         }
       }, 100);
     });


### PR DESCRIPTION
## Summary
- handle mobile menu link clicks by closing dropdown then navigating to the target URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f9054158832397c5306c7a7afb3e

## Summary by Sourcery

Bug Fixes:
- Prevent default mobile-nav link clicks, close the menu, then navigate to the link’s href after a short delay