### PR TITLE
Use htmlhint for HTML validation in CI

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install -g prettier html-validate eslint
+          npm install -g prettier htmlhint eslint
           
       - name: Lint and prettify HTML in public/
         run: |
@@ -32,7 +32,7 @@ jobs:
       - name: Validate HTML files
         run: |
           echo "🔍 Validating HTML files"
-          html-validate public/*.html
+          htmlhint "public/*.html"
           echo "✅ HTML validation complete"
 
       - name: Check for postMessage listeners in static HTML


### PR DESCRIPTION
## Summary
- switch CI dependency and validation step to htmlhint instead of html-validate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891174c7e64832397f2f09e0b19b9d2

## Summary by Sourcery

Switch HTML validation tool in CI workflow from html-validate to htmlhint

CI:
- Install htmlhint instead of html-validate in the CI environment
- Run htmlhint on public HTML files rather than html-validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated HTML validation in the deployment workflow to use HTMLHint instead of html-validate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->