### PR TITLE
fix: remove stray else in deploy workflow

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -107,15 +107,6 @@ jobs:
             
             echo "| ${page}.html | $status | $cors_status | $cors_header |" >> $GITHUB_STEP_SUMMARY
           done
-              else
-                cors_status="❌ Missing"
-                cors_header="Missing"
-                failed=1
-              fi
-            fi
-            
-            echo "| ${page}.html | $status | $cors_status | $cors_header |" >> $GITHUB_STEP_SUMMARY
-          done
           
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Security Headers Check" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- clean up duplicate else block in CI CORS validation loop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911a97ece883238badb76e21bf1697

## Summary by Sourcery

Streamline the CORS validation loop in the deploy CI workflow by removing a redundant else block.

Bug Fixes:
- Remove stray else block that duplicated the CORS status entry in the deploy CI summary.

CI:
- Clean up deploy-ci.yml by eliminating the extra else branch in the CORS validation loop.