### PR TITLE
chore: harden cors validation

### DIFF
--- a/.github/workflows/deploy-ci.yml
+++ b/.github/workflows/deploy-ci.yml
@@ -52,73 +52,86 @@ jobs:
             echo "✅ No postMessage listeners found in static HTML files"
           fi
 
-      - name: Validate CORS headers via HTTP requests
-        run: |
-          echo "🌐 Testing CORS headers and generating summary"
-          
-          # Base URL for testing - use production for accurate results
-          BASE_URL="https://www.macrosight.net"
-          
-          # Create markdown summary
-          echo "# MacroSight Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Page | Status | CORS Header | Access-Control-Allow-Origin |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|-------------|------------------------------|" >> $GITHUB_STEP_SUMMARY
-          
-          # Test all pages
-          pages=("home" "about" "projects" "resume" "contact" "invest" "experience" "embed")
-          failed=0
-          
-          for page in "${pages[@]}"; do
-            echo "Testing ${page}.html..."
-            
-            response=$(curl -s -I "${BASE_URL}/${page}.html" 2>/dev/null || echo "FAILED")
-            
-            if [[ "$response" == "FAILED" ]]; then
-              status="❌ FAILED"
-              cors_status="❌ N/A"
-              cors_header="N/A"
-              failed=1
-            else
+        - name: Validate CORS headers via HTTP requests
+          run: |
+            echo "🌐 Testing CORS headers and generating summary"
+
+            # Base URLs for testing. Use production if reachable, otherwise fall back to Netlify
+            PRIMARY_URL="https://www.macrosight.net"
+            FALLBACK_URL="https://macrosight.netlify.app"
+
+            # Create markdown summary
+            echo "# MacroSight Deployment Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Page | Status | CORS Header | Access-Control-Allow-Origin |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|--------|-------------|------------------------------|" >> $GITHUB_STEP_SUMMARY
+
+            # Test all pages
+            pages=("home" "about" "projects" "resume" "contact" "invest" "experience" "embed")
+            failed=0
+
+            for page in "${pages[@]}"; do
+              echo "Testing ${page}.html..."
+
+              # Try primary domain first
+              response=$(curl -s -I "${PRIMARY_URL}/${page}.html" 2>/dev/null)
               status_code=$(echo "$response" | head -n 1 | awk '{print $2}')
-              if [[ "$status_code" == "200" ]]; then
-                status="✅ 200 OK"
-              else
-                status="❌ $status_code"
-                failed=1
+
+              if [[ -z "$status_code" || "$status_code" != "200" ]]; then
+                echo "Primary domain unavailable, trying Netlify fallback..."
+                response=$(curl -s -I "${FALLBACK_URL}/${page}.html" 2>/dev/null || echo "FAILED")
+                status_code=$(echo "$response" | head -n 1 | awk '{print $2}')
               fi
-              
-              cors_header=$(echo "$response" | grep -i "access-control-allow-origin" | cut -d' ' -f2- | tr -d '\r\n' || echo "Not found")
-              
-              if [[ "$cors_header" != "Not found" ]]; then
-                cors_status="✅ Present"
-                
-                # Special check for embed.html - should have CORS: *
-                if [[ "$page" == "embed" && "$cors_header" != "*" ]]; then
-                  cors_status="❌ Wrong (should be *)"
+
+              if [[ "$response" == "FAILED" || -z "$status_code" ]]; then
+                status="❌ FAILED"
+                cors_status="❌ N/A"
+                cors_header="N/A"
+                failed=1
+              else
+                if [[ "$status_code" == "200" ]]; then
+                  status="✅ 200 OK"
+                else
+                  status="❌ $status_code"
                   failed=1
                 fi
-              else
-                cors_status="❌ Missing"
-                cors_header="Missing"
-                failed=1
+
+                cors_header=$(echo "$response" | grep -i "access-control-allow-origin" | cut -d' ' -f2- | tr -d '\r\n' || echo "Not found")
+
+                if [[ "$cors_header" != "Not found" ]]; then
+                  # All HTML files should return "*" to allow embedding
+                  if [[ "$cors_header" == "*" ]]; then
+                    cors_status="✅ *"
+                  else
+                    cors_status="❌ Wrong (should be *)"
+                    failed=1
+                  fi
+                else
+                  cors_status="❌ Missing"
+                  cors_header="Missing"
+                  failed=1
+                fi
               fi
-            fi
-            
-            echo "| ${page}.html | $status | $cors_status | $cors_header |" >> $GITHUB_STEP_SUMMARY
-          done
+
+              echo "| ${page}.html | $status | $cors_status | $cors_header |" >> $GITHUB_STEP_SUMMARY
+            done
           
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Security Headers Check" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          # Test security headers on main pages
-          main_response=$(curl -s -I "${BASE_URL}/home.html" 2>/dev/null || echo "FAILED")
-          
-          if [[ "$main_response" != "FAILED" ]]; then
-            hsts=$(echo "$main_response" | grep -i "strict-transport-security" || echo "")
-            csp=$(echo "$main_response" | grep -i "content-security-policy" || echo "")
-            xframe=$(echo "$main_response" | grep -i "x-frame-options" || echo "")
+            # Test security headers on main pages
+            main_response=$(curl -s -I "${PRIMARY_URL}/home.html" 2>/dev/null)
+            status_code=$(echo "$main_response" | head -n 1 | awk '{print $2}')
+
+            if [[ -z "$status_code" || "$status_code" != "200" ]]; then
+              main_response=$(curl -s -I "${FALLBACK_URL}/home.html" 2>/dev/null || echo "FAILED")
+            fi
+
+            if [[ "$main_response" != "FAILED" ]]; then
+              hsts=$(echo "$main_response" | grep -i "strict-transport-security" || echo "")
+              csp=$(echo "$main_response" | grep -i "content-security-policy" || echo "")
+              xframe=$(echo "$main_response" | grep -i "x-frame-options" || echo "")
             
             echo "- HSTS: $([ -n "$hsts" ] && echo "✅ Present" || echo "❌ Missing")" >> $GITHUB_STEP_SUMMARY
             echo "- CSP: $([ -n "$csp" ] && echo "✅ Present" || echo "❌ Missing")" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- make CORS header check fall back to Netlify domain if production domain is unreachable
- enforce Access-Control-Allow-Origin of * for all HTML pages
- fall back to Netlify domain when verifying security headers

## Testing
- `npm test`
- `./quick-test.sh` *(fails: INCORRECT should be `https://www.macrosight.net`)*

------
https://chatgpt.com/codex/tasks/task_e_68911c0ccf3c8323bfc992c475c8d859

## Summary by Sourcery

Harden CORS validation in the deploy CI workflow by adding a fallback Netlify domain when the primary site is unreachable, enforcing a wildcard Access-Control-Allow-Origin on all HTML pages, and applying the same fallback logic for security header checks

Enhancements:
- Add fallback to Netlify domain for CORS header validation when the production domain is unreachable
- Enforce Access-Control-Allow-Origin "*" for all HTML pages during CI deployment checks
- Apply fallback-to-Netlify logic for security header verifications on main pages

CI:
- Revamp deploy-ci GitHub Actions workflow to implement the new CORS and security header test flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of CORS and security header checks by adding fallback URL support in deployment validation.
  * Unified and tightened CORS header validation for all HTML pages, ensuring consistent security checks.
  * Enhanced reporting to reflect results from either the primary or fallback URL during deployment checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->