### PR TITLE
Add headshot image section

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -52,7 +52,7 @@
       <!-- Hero Section -->
       <div class="section">
         <div class="hero-section">
-          <div class="hero-image-placeholder">[Professional Headshot]</div>
+          <img src="/img/headshot.jpg" alt="Professional headshot" class="hero-image" />
           <h1>Taylor Dean</h1>
           <h2>Cloud Engineer | HPC Specialist</h2>
           <p class="hero-subtitle">

--- a/public/img/README.md
+++ b/public/img/README.md
@@ -1,0 +1,2 @@
+Place your professional headshot image in this directory as `headshot.jpg`.
+It will be displayed on the home page.

--- a/public/styles.css
+++ b/public/styles.css
@@ -258,20 +258,29 @@ nav a.active {
   background: var(--color-gradient-primary);
 }
 
+.hero-image,
 .hero-image-placeholder {
   width: 120px;
   height: 120px;
   border-radius: 50%;
-  background: var(--color-gradient-surface);
   border: 2px solid var(--color-accent);
   margin: 0 auto 2rem;
+  box-shadow: var(--border-glow);
+}
+
+.hero-image {
+  display: block;
+  object-fit: cover;
+}
+
+.hero-image-placeholder {
+  background: var(--color-gradient-surface);
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: var(--font-mono);
   font-size: 0.8rem;
   color: var(--color-muted);
-  box-shadow: var(--border-glow);
 }
 
 .cta-group {
@@ -692,10 +701,14 @@ footer {
     text-align: center;
   }
   
+  .hero-image,
   .hero-image-placeholder {
     width: 100px;
     height: 100px;
     margin: 0 auto 1.5rem;
+  }
+
+  .hero-image-placeholder {
     font-size: 0.8rem;
   }
   
@@ -980,6 +993,7 @@ footer {
 
 /* High DPI displays */
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  .hero-image,
   .hero-image-placeholder,
   .expertise-icon,
   .cert-badge {


### PR DESCRIPTION
## Summary
- add `/public/img` directory for a `headshot.jpg`
- replace hero placeholder with `<img>` tag on home page
- style new hero image and ensure responsive/high-DPI support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a60f3b050832382ee8cd42622102e

## Summary by Sourcery

Add a professional headshot section to the home page and style it responsively with high-DPI support

New Features:
- Replace hero placeholder with professional headshot image on the homepage

Enhancements:
- Add CSS styling for the hero image including circular cropping, box shadow, object-fit support, and high-DPI responsiveness

Documentation:
- Add public/img directory with README instructing to place headshot.jpg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Replaced the hero placeholder with a real profile image on the home page.
- Style
  - Updated hero image visuals with circular framing, border, and subtle glow.
  - Improved responsiveness: image scales on mobile and in footer contexts.
  - Enhanced clarity on high‑DPI screens with crisper rendering.
- Documentation
  - Added guidance on where to place the headshot image for display on the home page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->