### PR TITLE
Fix headshot path and document image embedding

### DIFF
--- a/public/header.html
+++ b/public/header.html
@@ -1,3 +1,4 @@
+<!-- htmlhint doctype-first:false -->
 <header class="site-header">
   <div class="section header-content">
     <a class="brand" href="/"><span>MacroSight</span></a>

--- a/public/home.html
+++ b/public/home.html
@@ -27,10 +27,14 @@
       <div class="section">
         <div class="hero-section">
           <picture class="avatar">
-            <source srcset="/images/profile.webp" type="image/webp" />
-            <source srcset="/images/profile.jpg" type="image/jpeg" />
+            <source
+              srcset="/img/headshot.webp 1x, /img/headshot@2x.webp 2x"
+              type="image/webp"
+            />
             <img
-              src="/images/profile.jpg"
+              src="/img/headshot.jpg"
+              srcset="/img/headshot.jpg 1x, /img/headshot@2x.jpg 2x"
+              sizes="(max-width: 600px) 60vw, 280px"
               alt="Portrait of Taylor Dean"
               width="320"
               height="320"

--- a/public/img/README.md
+++ b/public/img/README.md
@@ -4,5 +4,7 @@ This directory stores images served by the site.
 
 - `headshot.jpg`: Standard resolution (e.g., 400x400)
 - `headshot@2x.jpg`: Double-resolution version for high-DPI displays
+- `headshot.webp`: Optional WebP version for modern browsers
+- `headshot@2x.webp`: Optional double-resolution WebP
 
-Replace these placeholder files with your own headshot while keeping the same filenames. Additional images can also be added here and referenced in pages via `/img/<filename>` paths.
+Upload your headshot files with these exact names to ensure the home page's `<picture>` element embeds them correctly. Additional images can also be added here and referenced in pages via `/img/<filename>` paths.


### PR DESCRIPTION
## Summary
- refactor home hero to load `/img/headshot` assets with responsive `srcset`
- document required headshot file names and add optional WebP variants
- silence htmlhint warning on header partial

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8cd3b3c483239bbc32bc3f71541b

## Summary by Sourcery

Improve image embedding by updating headshot paths and responsive sources, enhance documentation for headshot assets, and silence a lint warning in the header

Enhancements:
- Refactor home hero to load headshot assets from `/img` with responsive `srcset` for both WebP and JPEG variants

Documentation:
- Document required headshot filenames and optional WebP variants in the public/img README

Chores:
- Add HTMLHint directive to suppress `doctype-first` warning in the header partial