### PR TITLE
fix: target image elements for fluid media

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -29,7 +29,6 @@
 
 /* Fluid media: prevent overflow on small screens */
 img,
-picture,
 video,
 canvas,
 svg,


### PR DESCRIPTION
## Summary
- target `<img>` only in fluid media CSS so responsive layout applies to images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a92eff8ec8323892a336f1c350f3a

## Summary by Sourcery

Bug Fixes:
- Exclude picture elements from the fluid media overflow rule so responsive styling applies correctly to images only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive media behavior on small screens by refining fluid media styling. Images, videos, canvases, SVGs, and iframes remain fully fluid, reducing overflow and layout issues, while avoiding unintended effects on picture elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->