### PR TITLE
refactor: streamline fluid media rule

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -28,14 +28,15 @@
 /* === Responsive Hardening Layer === */
 
 /* Fluid media: prevent overflow on small screens */
-img,
-video,
-canvas,
-svg,
-iframe {
+:is(img, video, canvas, svg, iframe) {
   max-width: 100%;
   height: auto;
   display: block;
+}
+
+/* Ensure <picture> elements remain fluid via their <img> */
+picture > img {
+  max-width: 100%;
 }
 
 /* Prevent horizontal scroll with wide code/tables */


### PR DESCRIPTION
## Summary
- simplify fluid media selector with `:is()`
- ensure `<picture>` elements stay responsive via inner `img`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9500359c83238dd62f70ac179d32

## Summary by Sourcery

Streamline the fluid media CSS rule using the :is() pseudo-class and add a rule to ensure <picture> elements remain responsive

Enhancements:
- Consolidate individual media selectors into a single :is() rule for img, video, canvas, svg, and iframe
- Add a picture > img rule to enforce max-width on images within picture elements