### PR TITLE
refactor: reuse placeholder image and document menu toggle

### DIFF
--- a/public/home.js
+++ b/public/home.js
@@ -23,7 +23,9 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
+// Listen for mobile menu visibility changes dispatched by mobile-nav.js
 document.addEventListener("mobile-menu-toggle", (e) => {
+  // detail: { isActive: boolean }
   analytics.track("mobile_menu_toggle", {
     action: e.detail.isActive ? "open" : "close",
   });

--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -1,10 +1,14 @@
 // public/mobile-nav.js
+// Dispatches a 'mobile-menu-toggle' CustomEvent with { detail: { isActive: boolean } }
+// so other scripts can react to mobile menu state changes.
 (function () {
-  function qs(sel) { return document.querySelector(sel); }
+  function qs(sel) {
+    return document.querySelector(sel);
+  }
 
   function setupMenu() {
-    const btn   = qs('#menu-toggle');
-    const panel = qs('#mobile-nav');
+    const btn = qs("#menu-toggle");
+    const panel = qs("#mobile-nav");
     if (!btn || !panel) return;
 
     let open = false;
@@ -12,45 +16,49 @@
     function setState(next) {
       open = next;
       panel.hidden = !open;
-      document.documentElement.classList.toggle('nav-open', open);
-      btn.setAttribute('aria-expanded', String(open));
-      btn.setAttribute('aria-label', open ? 'Close navigation' : 'Open navigation');
+      document.documentElement.classList.toggle("nav-open", open);
+      btn.setAttribute("aria-expanded", String(open));
+      btn.setAttribute(
+        "aria-label",
+        open ? "Close navigation" : "Open navigation",
+      );
 
       // Announce state to any listeners (analytics or page scripts)
+      // Custom event payload: { detail: { isActive: boolean } }
+      // Consumers can listen on `document` for 'mobile-menu-toggle'
       try {
         document.dispatchEvent(
-          new CustomEvent('mobile-menu-toggle', { detail: { isActive: open } })
+          new CustomEvent("mobile-menu-toggle", { detail: { isActive: open } }),
         );
       } catch (e) {}
 
       // iOS-friendly scroll lock
-      document.body.style.overflow = open ? 'hidden' : '';
-      document.body.style.touchAction = open ? 'none' : '';
+      document.body.style.overflow = open ? "hidden" : "";
+      document.body.style.touchAction = open ? "none" : "";
 
       // Keep focus on the toggle for accessibility
       btn.focus();
     }
 
     // Close when a nav link is tapped
-    panel.addEventListener('click', (e) => {
-      const link = e.target.closest('a');
+    panel.addEventListener("click", (e) => {
+      const link = e.target.closest("a");
       if (link) setState(false);
     });
 
-    btn.addEventListener('click', () => setState(!open));
-    document.addEventListener('keydown', (e) => {
-      if (open && e.key === 'Escape') setState(false);
+    btn.addEventListener("click", () => setState(!open));
+    document.addEventListener("keydown", (e) => {
+      if (open && e.key === "Escape") setState(false);
     });
 
-    window.addEventListener('resize', () => {
+    window.addEventListener("resize", () => {
       if (window.innerWidth >= 1024 && open) setState(false);
     });
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupMenu);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setupMenu);
   } else {
     setupMenu();
   }
 })();
-

--- a/public/placeholder-img.js
+++ b/public/placeholder-img.js
@@ -1,0 +1,20 @@
+// public/placeholder-img.js
+// Injects a shared placeholder image for elements with `data-placeholder-img`.
+// Uses an optional `data-alt` attribute for the image's alt text.
+(function () {
+  function init() {
+    document.querySelectorAll("[data-placeholder-img]").forEach((el) => {
+      const alt = el.getAttribute("data-alt") || "";
+      el.innerHTML = `
+          <picture>
+            <img src="/img/Placeholder.jpg" width="300" height="200" alt="${alt}" loading="lazy" decoding="async" class="placeholder-img" />
+          </picture>`;
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/public/projects.html
+++ b/public/projects.html
@@ -50,17 +50,7 @@
             target="_blank"
             rel="noopener"
           >
-            <picture>
-              <img
-                src="/img/Placeholder.jpg"
-                width="300"
-                height="200"
-                alt="Cloud HPC infrastructure"
-                loading="lazy"
-                decoding="async"
-                class="placeholder-img"
-              />
-            </picture>
+            <div data-placeholder-img data-alt="Cloud HPC infrastructure"></div>
             <h3>Cloud HPC Infrastructure</h3>
             <p>
               Terraform modules and Kubernetes configs for scalable GPU
@@ -73,17 +63,7 @@
             target="_blank"
             rel="noopener"
           >
-            <picture>
-              <img
-                src="/img/Placeholder.jpg"
-                width="300"
-                height="200"
-                alt="Analytics pipeline"
-                loading="lazy"
-                decoding="async"
-                class="placeholder-img"
-              />
-            </picture>
+            <div data-placeholder-img data-alt="Analytics pipeline"></div>
             <h3>Real-time Analytics Pipeline</h3>
             <p>
               Event-driven data pipeline processing billions of events per day.
@@ -95,17 +75,7 @@
             target="_blank"
             rel="noopener"
           >
-            <picture>
-              <img
-                src="/img/Placeholder.jpg"
-                width="300"
-                height="200"
-                alt="API gateway"
-                loading="lazy"
-                decoding="async"
-                class="placeholder-img"
-              />
-            </picture>
+            <div data-placeholder-img data-alt="API gateway"></div>
             <h3>High-Performance API Gateway</h3>
             <p>Service mesh and gateway built for low-latency microservices.</p>
           </a>
@@ -137,5 +107,6 @@
     </footer>
 
     <script src="/include-header.js"></script>
+    <script src="/placeholder-img.js"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -45,10 +45,15 @@ code {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* Keep tables responsive without breaking semantics.
+   Wrap tables in a .table-wrapper to enable horizontal scrolling. */
+.table-wrapper {
+  overflow-x: auto;
+}
+
 table {
   width: 100%;
-  display: block;
-  overflow-x: auto;
 }
 
 /* Respect user font scaling and keep consistent sizing */


### PR DESCRIPTION
## Summary
- extract repeated project thumbnail markup into a reusable placeholder image script and include it in projects page
- restore table semantics by moving horizontal scroll to a wrapper instead of the table element
- document `mobile-menu-toggle` custom event payload and listening example for analytics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9eb20d588323ab7e5196cf02348b