### PR TITLE
Resolve CSP and Playwright server command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -40,7 +40,7 @@
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self' https://macrosight.net"
+    Content-Security-Policy = "default-src 'self' https://macrosight.net https://macrosight.netlify.app"
 
 [[headers]]
   for = "/img/*"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     baseURL: 'http://localhost:4173',
   },
   webServer: {
-
+    command: 'vite public --port 4173',
     port: 4173,
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary
- extend Content-Security-Policy to allow netlify app domain
- specify Vite command for Playwright's test server

## Testing
- `npm test` *(fails: redirect status expectations)*

------
https://chatgpt.com/codex/tasks/task_e_689ab12c94048323ba860060590438e9