### PR TITLE
Improve mobile navigation accessibility

### DIFF
--- a/public/header.html
+++ b/public/header.html
@@ -27,6 +27,7 @@
 
   <!-- Mobile menu panel -->
   <div class="mobile-nav" id="mobile-nav" hidden role="dialog" aria-modal="true">
+    <button class="close-nav" type="button" aria-label="Close navigation">&times;</button>
     <nav aria-label="Mobile Primary">
       <a href="/home">Home</a>
       <a href="/about">About</a>

--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -3,11 +3,26 @@
   function qs(sel) { return document.querySelector(sel); }
 
   function setupMenu() {
-    const btn   = qs('#menu-toggle');
+    const btn = qs('#menu-toggle');
     const panel = qs('#mobile-nav');
-    if (!btn || !panel) return;
+    const close = panel ? panel.querySelector('.close-nav') : null;
+    if (!btn || !panel || !close) return;
 
     let open = false;
+
+    function trapFocus(e) {
+      if (!open || e.key !== 'Tab') return;
+      const focusables = panel.querySelectorAll('a, button');
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
 
     function setState(next) {
       open = next;
@@ -27,17 +42,23 @@
       document.body.style.overflow = open ? 'hidden' : '';
       document.body.style.touchAction = open ? 'none' : '';
 
-      // Keep focus on toggle for accessibility
-      btn.focus();
+      if (open) {
+        close.focus();
+      } else {
+        btn.focus();
+      }
     }
 
-    // Close on link click inside panel
+    // Close on link click or overlay click inside panel
     panel.addEventListener('click', (e) => {
       const link = e.target.closest('a');
-      if (link) setState(false);
+      if (link || e.target === panel) setState(false);
     });
 
+    panel.addEventListener('keydown', trapFocus);
+
     btn.addEventListener('click', () => setState(!open));
+    close.addEventListener('click', () => setState(false));
     document.addEventListener('keydown', (e) => {
       if (open && e.key === 'Escape') setState(false);
     });


### PR DESCRIPTION
## Summary
- add explicit close button to the mobile navigation overlay
- trap focus within the mobile menu and allow overlay click to dismiss

## Testing
- `npx playwright install` *(fails: Download failed 403)*
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689ac83a9d908323a521e2b8930aa8b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close button in the mobile navigation panel for quicker dismissal.
  * Clicking the panel background now closes the mobile navigation.
  * Improved keyboard accessibility: focus is trapped within the open mobile navigation and cycles with Tab/Shift+Tab.
  * Enhanced focus management: focus moves to the close button when opened and returns to the menu toggle when closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->