### PR TITLE
fix: correct header brand name

### DIFF
--- a/public/header.html
+++ b/public/header.html
@@ -2,7 +2,7 @@
 <header class="site-header" role="banner">
   <a class="skip-link" href="#main-content">Skip to content</a>
   <div class="section header-content">
-    <a class="brand" href="/"><span>MACROsite</span></a>
+    <a class="brand" href="/"><span>MacroSight</span></a>
 
     <button
       id="menu-toggle"


### PR DESCRIPTION
## Summary
- fix header brand text to MacroSight

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68a22ea7840c83238e42f524d04b3d6a

## Summary by Sourcery

Bug Fixes:
- Update the header brand name from MACROsite to MacroSight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated site header branding from “MACROsite” to “MacroSight” for a clearer, consistent brand name across the app.
  * Change is purely visual; navigation links, header structure, and behavior remain unchanged.
  * Appears wherever the shared header is displayed.

* **Chores**
  * Minor branding alignment to match current naming conventions, with no impact on functionality or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->