### PR TITLE
Improve smoke test diagnostics and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm cache clean --force
 npm install
 ```
 
-Validate HTML and JS before committing:
+Validate CSS and JS before committing:
 
 ```bash
 npm run lint
@@ -30,7 +30,7 @@ npm run lint
 
 ## Running tests locally
 
-The CI pipeline runs Playwright end-to-end tests after validating HTML. To run the same checks locally:
+The CI pipeline runs Playwright end-to-end tests after validating CSS links. To run the same checks locally:
 
 ```bash
 npm ci


### PR DESCRIPTION
## Summary
- log retry count and last error while waiting for the local server to start
- verify home.html links to /styles.css in smoke test
- clarify README references to CSS validation

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run npx playwright install)*
- `npx playwright install chromium` *(fails: Download failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a3325408323992d51cf7ec4e21f

## Summary by Sourcery

Enhance smoke-local script to log retry attempts and errors, return response bodies, and assert the presence of the stylesheet link in home.html; update README to clarify CSS validation steps

Enhancements:
- Collect and return response body in smoke-local HTTP requests
- Log retry count and last error during server startup and include error details in final error message
- Add a smoke test assertion for the <link rel="stylesheet" href="/styles.css"> tag in home.html

Documentation:
- Clarify README instructions to reference CSS validation instead of HTML validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README to reference CSS and JS validation in pre-commit and local CI descriptions; clarified workflow details around CSS link checks. No functional changes.
- Tests
  - Strengthened local smoke tests to capture response bodies, verify the home page includes a stylesheet link, and surface clearer retry/error messages for easier troubleshooting and improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->