### PR TITLE
Ensure server shutdown and optional e2e deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
         "eslint": "^9.33.0",
         "prettier": "^3.2.5"
       },
+      "optionalDependencies": {
+        "@playwright/test": "^1.44.0",
+        "html-validate": "^9.4.0"
+      },
       "engines": {
         "node": "20.x"
       }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "node": "20.x"
   },
   "devDependencies": {
-    "@playwright/test": "^1.44.0",
     "eslint": "^9.33.0",
-    "html-validate": "^9.4.0",
     "knip": "^3.0.0",
     "npm-deprecations": "^1.3.0",
     "prettier": "^3.2.5"
+  },
+  "optionalDependencies": {
+    "@playwright/test": "^1.44.0",
+    "html-validate": "^9.4.0"
   }
 }

--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -1,2 +1,3 @@
 export const DEFAULT_PORT = 4173;
-export const PORT = Number(process.env.PORT || DEFAULT_PORT);
+const parsedPort = Number(process.env.PORT);
+export const PORT = Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : DEFAULT_PORT;

--- a/scripts/run-playwright.mjs
+++ b/scripts/run-playwright.mjs
@@ -6,8 +6,10 @@ async function main() {
     await import('@playwright/test');
   } catch {
     console.log('[@playwright/test] not installed; skipping e2e tests.');
+    process.exit(0);
     return;
   }
+  console.log('Running Playwright end-to-end tests...');
   const args = process.argv.slice(2);
   const child = spawn('npx', ['playwright', 'test', ...args], { stdio: 'inherit', shell: true });
   child.on('exit', code => process.exit(code));

--- a/scripts/smoke-local.js
+++ b/scripts/smoke-local.js
@@ -91,7 +91,7 @@ async function waitForServer(retries = 50) {
     console.log('Local smoke test passed');
   } finally {
     if (serverProc) serverProc.kill();
-    if (server) server.close();
+    if (server) await new Promise(r => server.close(r));
   }
 })();
 

--- a/scripts/test-a11y.mjs
+++ b/scripts/test-a11y.mjs
@@ -22,7 +22,7 @@ async function main() {
     console.error(err);
     process.exit(1);
   } finally {
-    server.close();
+    await new Promise(resolve => server.close(resolve));
   }
 }
 


### PR DESCRIPTION
## Summary
- validate `PORT` env var and fall back to default
- skip Playwright e2e tests gracefully when deps missing
- move Playwright and html-validate to optional dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2627b056c8323ba447d16a5d01ce5

## Summary by Sourcery

Enhance developer scripts by validating the PORT environment variable with a fallback, properly awaiting server shutdowns, and making Playwright and HTML-validate optional to gracefully skip e2e tests when deps are missing.

Enhancements:
- Validate the PORT environment variable and fall back to the default if it’s missing or invalid
- Await server.close() in smoke-local and accessibility scripts to ensure the server fully shuts down
- Gracefully skip Playwright end-to-end tests when optional dependencies are not installed, exiting successfully
- Log a message before running Playwright e2e tests

Build:
- Move @playwright/test and html-validate from devDependencies to optionalDependencies