### PR TITLE
Allow Wix parent frames and structured injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,18 @@ npx playwright show-report
 - Directory guides: [src/pages/README.md](src/pages/README.md), [src/public/README.md](src/public/README.md), [src/backend/README.md](src/backend/README.md)
 
 ## 🏗 **DEPLOYMENT STATUS**
+
 - **Static Site**: ✅ Deployed on Netlify (`public/` folder)
-- **Wix Integration**: ✅ Velo code in `src/` folder  
+- **Wix Integration**: ✅ Velo code in `src/` folder
 - **CORS Headers**: ✅ Configured for cross-origin embedding
 - **Security**: ✅ HSTS, CSP, and other security headers active
 
 ## File Structure
 
 ### Static HTML Pages (`public/`)
+
 - `home.html` - Pure static home page
-- `about.html` - Pure static about page  
+- `about.html` - Pure static about page
 - `contact.html` - Pure static contact page
 - `experience.html` - Pure static experience page
 - `projects.html` - Pure static projects page
@@ -80,15 +82,18 @@ npx playwright show-report
 - `404.html` - Pure static 404 error page
 
 ### Wix Integration Pages
+
 - `embed.html` - **CRITICAL**: Dedicated postMessage listener for iframe embedding
 - Has loading spinner, content validation, and whitelisted origins
 
 ### Assets
+
 - `styles.css` - Global stylesheet with loader styles
-- `robots.txt` - SEO crawler instructions  
+- `robots.txt` - SEO crawler instructions
 - `sitemap.xml` - Site structure for search engines
 
 ### Wix Velo Code (`src/`)
+
 - `public/wix-velo-integration.js` - **WEB MODULE**: Core integration helper (accessible by all Velo code)
 - `public/globalStyles.js` - **WEB MODULE**: Shared styling utilities
 - `public/injectHtml.js` - **WEB MODULE**: HTML injection utilities
@@ -98,19 +103,27 @@ npx playwright show-report
 ## CORS & Security Configuration
 
 ### HTML Files (`/*.html`)
+
 - `Access-Control-Allow-Origin: *` - Allows cross-origin fetching for Wix integration
 
 ### All Other Files (`/*`)
+
 - `Access-Control-Allow-Origin: https://www.macrosight.net` - Restrictive CORS
-- Security headers: HSTS, X-Frame-Options, CSP, etc.
+- Security headers: HSTS, CSP with `frame-ancestors` for Wix, etc.
 
 ## postMessage Architecture
 
 ### Allowed Origins
-- `https://www.macrosight.net`
-- `https://macrosight.netlify.app`
+
+- `https://www.wix.com`
+- `https://*.wix.com`
+- `https://*.wixsite.com`
+- `https://editor.wix.com`
+- `https://editor.wixstudio.com`
+- `https://manage.wix.com`
 
 ### Safety Features
+
 - Rejects HTML containing `<head>` tags
 - Only injects into `document.body`
 - Hides loader on successful injection
@@ -119,16 +132,19 @@ npx playwright show-report
 ## Wix-Velo Integration
 
 1. **Setup iframe**: Point to `embed.html` or use specific embed pages
-2. **Fetch content**: Use `wix-fetch` to get HTML from Netlify
-3. **Post message**: Send HTML content to iframe via postMessage
+2. **Fetch content**: Use `wix-fetch` to get HTML and CSS from Netlify
+3. **Post message**: Send `{ type: 'INJECT', html, css }` to iframe via `postMessage`
 4. **Display**: Content replaces loader in iframe
 
 Example:
+
 ```javascript
 // In Wix Velo page code
-const response = await fetch('https://www.macrosight.net/home.html');
-const html = await response.text();
-iframe.postMessage(html, 'https://www.macrosight.net');
+const [html, css] = await Promise.all([
+  fetch('https://macrosight.net/home.html').then((r) => r.text()),
+  fetch('https://macrosight.net/styles.css').then((r) => r.text()),
+]);
+iframe.postMessage({ type: 'INJECT', html, css }, 'https://macrosight.net');
 ```
 
 ## CSS Link Validation
@@ -171,6 +187,7 @@ curl -I https://www.macrosight.net/
 ## SEO & Launch Files
 
 This site includes:
+
 - `/robots.txt` (allows all, points to sitemap)
 - `/sitemap.xml` (lists all public pages)
 
@@ -179,26 +196,28 @@ Both are in `/public` and will be live at the root of your deployed site for sea
 All page scripts should import global styles like this for Wix/Velo compatibility:
 
 ```js
-import { injectGlobalStyles } from "public/globalStyles";
-import { injectHtml } from "public/wix-velo-integration";
+import { injectGlobalStyles } from 'public/globalStyles';
+import { injectHtml } from 'public/wix-velo-integration';
 ```
 
 Call `injectGlobalStyles()` at the top of your `$w.onReady()` function, then call `injectHtml('componentId', 'pageName')` to load content.
 
 # Git Integration & Wix CLI <img align="left" src="https://user-images.githubusercontent.com/89579857/185785022-cab37bf5-26be-4f11-85f0-1fac63c07d3b.png">
 
-This repo is part of Git Integration & Wix CLI, a set of tools that allows you to write, test, and publish code for your Wix site locally on your computer. 
+This repo is part of Git Integration & Wix CLI, a set of tools that allows you to write, test, and publish code for your Wix site locally on your computer.
 
 Connect your site to GitHub, develop in your favorite IDE, test your code in real time, and publish your site from the command line.
 
 ## Set up this repository in your IDE
+
 This repo is connected to a Wix site. That site tracks this repo's default branch. Any code committed and pushed to that branch from your local IDE appears on the site.
 
 Before getting started, make sure you have the following things installed:
-* [Git](https://git-scm.com/download)
-* [Node](https://nodejs.org/en/download/), version 14.8 or later.
-* [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or [yarn](https://yarnpkg.com/getting-started/install)
-* An SSH key [added to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+
+- [Git](https://git-scm.com/download)
+- [Node](https://nodejs.org/en/download/), version 14.8 or later.
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) or [yarn](https://yarnpkg.com/getting-started/install)
+- An SSH key [added to your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
 To set up your local environment and start coding locally, do the following:
 
@@ -212,11 +231,13 @@ To set up your local environment and start coding locally, do the following:
 For more information, see [Setting up Git Integration & Wix CLI](https://support.wix.com/en/article/velo-setting-up-git-integration-wix-cli-beta).
 
 ## Write Velo code in your IDE
+
 Once your repo is set up, you can write code in it as you would in any other non-Wix project. The repo's file structure matches the [public](https://support.wix.com/en/article/velo-working-with-the-velo-sidebar#public), [backend](https://support.wix.com/en/article/velo-working-with-the-velo-sidebar#backend), and [page code](https://support.wix.com/en/article/velo-working-with-the-velo-sidebar#page-code) sections in Editor X.
 
 Learn more about [this repo's file structure](https://support.wix.com/en/article/velo-understanding-your-sites-github-repository-beta).
 
 ## Test your code with the Local Editor
+
 The Local Editor allows you test changes made to your site in real time. The code in your local IDE is synced with the Local Editor, so you can test your changes before committing them to your repo. You can also change the site design in the Local Editor and sync it with your IDE.
 
 Start the Local Editor by navigating to this repo's directory in your terminal and running `wix dev`.
@@ -224,9 +245,11 @@ Start the Local Editor by navigating to this repo's directory in your terminal a
 For more information, see [Working with the Local Editor](https://support.wix.com/en/article/velo-working-with-the-local-editor-beta).
 
 ## Preview and publish with the Wix CLI
+
 The Wix CLI is a tool that allows you to work with your site locally from your computer's terminal. You can use it to build a preview version of your site and publish it. You can also use the CLI to install [approved npm packages](https://support.wix.com/en/article/velo-working-with-npm-packages) to your site.
 
 Learn more about [working with the Wix CLI](https://support.wix.com/en/article/velo-working-with-the-wix-cli-beta).
 
 ## Invite contributors to work with you
+
 Git Integration & Wix CLI extends Editor X's [concurrent editing](https://support.wix.com/en/article/editor-x-about-concurrent-editing) capabilities. Invite other developers as collaborators on your [site](https://support.wix.com/en/article/inviting-people-to-contribute-to-your-site) and your [GitHub repo](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository). Multiple developers can work on a site's code at once.

--- a/comprehensive-test.sh
+++ b/comprehensive-test.sh
@@ -64,21 +64,21 @@ echo "==========================="
 
 # Test 1: embed.html (critical for Wix)
 ((total_tests++))
-if test_url_with_retry "https://macrosight.netlify.app/embed.html" "*" "embed.html (Wix embedding)"; then
+if test_url_with_retry "https://macrosight.net/embed.html" "*" "embed.html (Wix embedding)"; then
     ((passed_tests++))
 fi
 echo ""
 
 # Test 2: home.html (general HTML)
 ((total_tests++))
-if test_url_with_retry "https://macrosight.netlify.app/home.html" "*" "home.html (HTML files)"; then
+if test_url_with_retry "https://macrosight.net/home.html" "*" "home.html (HTML files)"; then
     ((passed_tests++))
 fi
 echo ""
 
 # Test 3: styles.css (assets - should be restricted)
 ((total_tests++))
-if test_url_with_retry "https://macrosight.netlify.app/styles.css" "https://www.macrosight.net" "styles.css (assets)"; then
+if test_url_with_retry "https://macrosight.net/styles.css" "https://macrosight.net" "styles.css (assets)"; then
     ((passed_tests++))
 fi
 echo ""
@@ -88,7 +88,7 @@ echo "========================"
 
 # Test security headers
 echo "🔍 Testing security headers on home.html..."
-security_response=$(curl -s -I "https://macrosight.netlify.app/home.html" 2>/dev/null)
+security_response=$(curl -s -I "https://macrosight.net/home.html" 2>/dev/null)
 
 ((total_tests++))
 if echo "$security_response" | grep -qi "strict-transport-security"; then
@@ -123,7 +123,7 @@ echo "======================"
 critical_files=("home.html" "about.html" "embed.html" "projects.html" "contact.html")
 for file in "${critical_files[@]}"; do
     ((total_tests++))
-    status=$(curl -s -I "https://macrosight.netlify.app/$file" | head -n 1 | awk '{print $2}')
+    status=$(curl -s -I "https://macrosight.net/$file" | head -n 1 | awk '{print $2}')
     if [[ "$status" == "200" ]]; then
         echo "   ✅ $file: Available (200)"
         ((passed_tests++))
@@ -198,7 +198,7 @@ fi
 echo ""
 echo "🔗 USEFUL LINKS:"
 echo "   Netlify Dashboard: https://app.netlify.com"
-echo "   Live Site: https://macrosight.netlify.app"
+echo "   Live Site: https://macrosight.net"
 echo "   GitHub Actions: https://github.com/TylrDn/my-site-3/actions"
 echo ""
 echo "📝 For detailed testing: see TESTING-GUIDE.md"

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,6 @@
     Access-Control-Allow-Headers = "Content-Type"
     Strict-Transport-Security = "max-age=15768000; includeSubDomains; preload"
     X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "strict-origin-when-cross-origin"
 
@@ -37,10 +36,9 @@
     Access-Control-Allow-Headers = "Content-Type"
     Strict-Transport-Security = "max-age=15768000; includeSubDomains; preload"
     X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self' https://macrosight.net https://macrosight.netlify.app"
+    Content-Security-Policy = "default-src 'self' https://macrosight.net; frame-ancestors https://www.wix.com https://*.wix.com https://*.wixsite.com https://editor.wix.com https://editor.wixstudio.com https://manage.wix.com"
 
 [[headers]]
   for = "/img/*"

--- a/public/embed.html
+++ b/public/embed.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
     <title>MacroSight Embed</title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/styles.css" />
     <style>
       .loader {
         display: flex;
@@ -16,7 +16,7 @@
       }
 
       .loader::after {
-        content: "";
+        content: '';
         width: 20px;
         height: 20px;
         margin-left: 10px;
@@ -27,8 +27,12 @@
       }
 
       @keyframes spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
       }
     </style>
     <script defer src="/scripts/responsive-iframe.js"></script>
@@ -39,47 +43,68 @@
       This page is meant to be embedded.
       <a href="https://www.macrosight.net/home">Go to Home</a>
     </noscript>
-    <div class="iframe-container" style="--iframe-aspect:16/9">
+    <div class="iframe-container" style="--iframe-aspect: 16/9">
       <iframe data-ri title="Embedded content"></iframe>
     </div>
     <script>
       // Hardened postMessage injection for Wix Velo
-      const ALLOWED_ORIGINS = [
-        "https://www.macrosight.net",
-        "https://macrosight.netlify.app"
-      ];
+      const ALLOWED_PARENTS = new Set([
+        'https://www.wix.com',
+        'https://*.wix.com',
+        'https://*.wixsite.com',
+        'https://editor.wix.com',
+        'https://editor.wixstudio.com',
+        'https://manage.wix.com',
+      ]);
+
       // Test-only: allow local origins to simulate Wix in CI
       try {
         if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
-          ALLOWED_ORIGINS.push(window.location.origin);
+          ALLOWED_PARENTS.add(window.location.origin);
         }
       } catch {}
 
-      function safeInject(html) {
-        // Strip <head> content and inject only <body> content
-        if (typeof html !== "string") return false;
+      function isAllowedOrigin(origin) {
+        return [...ALLOWED_PARENTS].some((p) =>
+          new RegExp('^' + p.replace(/\*/g, '.*') + '$').test(origin)
+        );
+      }
 
-        // Extract body content, removing <head> entirely
+      function safeInject({ html, css }) {
+        if (typeof html !== 'string') return false;
+
         const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
         const bodyContent = bodyMatch ? bodyMatch[1] : html;
 
-        // Additional safety check - don't allow script or style tags
         if (/<(script|style)[\s>]/i.test(bodyContent)) return false;
 
-        document.body.innerHTML = bodyContent;
+        document.body.innerHTML = '';
+        if (typeof css === 'string' && css.trim() !== '') {
+          const style = document.createElement('style');
+          style.textContent = css;
+          document.body.appendChild(style);
+        }
+        document.body.insertAdjacentHTML('beforeend', bodyContent);
         return true;
       }
 
-      window.addEventListener("message", (event) => {
-        if (!ALLOWED_ORIGINS.includes(event.origin)) return;
+      window.addEventListener(
+        'message',
+        (event) => {
+          if (!isAllowedOrigin(event.origin)) return;
+          const { type, html, css } = event.data || {};
+          if (type !== 'INJECT') return;
 
-        if (safeInject(event.data)) {
-          const loader = document.querySelector(".loader");
-          if (loader) loader.style.display = "none";
-        } else {
-          document.body.innerHTML = '<div style="padding:2em;text-align:center;color:#c00;">Sorry, content failed to load. Please try again later.</div>';
-        }
-      }, false);
+          if (safeInject({ html, css })) {
+            const loader = document.querySelector('.loader');
+            if (loader) loader.style.display = 'none';
+          } else {
+            document.body.innerHTML =
+              '<div style="padding:2em;text-align:center;color:#c00;">Sorry, content failed to load. Please try again later.</div>';
+          }
+        },
+        false
+      );
     </script>
     <script src="/mobile-nav.js" defer></script>
   </body>

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -5,7 +5,7 @@ echo "===================================="
 echo ""
 
 # Check if we're testing the right domain
-echo "🔍 Testing Netlify deployment..."
+echo "🔍 Testing production deployment..."
 echo ""
 
 # Function to extract header value
@@ -17,7 +17,7 @@ get_header() {
 
 # Test embed.html CORS
 echo "📍 Testing embed.html CORS header..."
-EMBED_CORS=$(get_header "https://macrosight.netlify.app/embed.html" "access-control-allow-origin")
+EMBED_CORS=$(get_header "https://macrosight.net/embed.html" "access-control-allow-origin")
 echo "   Result: $EMBED_CORS"
 if [[ "$EMBED_CORS" == "*" ]]; then
     echo "   ✅ CORRECT (allows Wix embedding)"
@@ -29,7 +29,7 @@ echo ""
 
 # Test home.html CORS
 echo "📍 Testing home.html CORS header..."
-HOME_CORS=$(get_header "https://macrosight.netlify.app/home.html" "access-control-allow-origin")
+HOME_CORS=$(get_header "https://macrosight.net/home.html" "access-control-allow-origin")
 echo "   Result: $HOME_CORS"
 if [[ "$HOME_CORS" == "*" ]]; then
     echo "   ✅ CORRECT (allows cross-origin fetching)"
@@ -41,19 +41,19 @@ echo ""
 
 # Test CSS CORS (should be restricted)
 echo "📍 Testing styles.css CORS header..."
-CSS_CORS=$(get_header "https://macrosight.netlify.app/styles.css" "access-control-allow-origin")
+CSS_CORS=$(get_header "https://macrosight.net/styles.css" "access-control-allow-origin")
 echo "   Result: $CSS_CORS"
-if [[ "$CSS_CORS" == "https://www.macrosight.net" ]]; then
+if [[ "$CSS_CORS" == "https://macrosight.net" ]]; then
     echo "   ✅ CORRECT (properly restricted)"
 else
-    echo "   ❌ INCORRECT (should be 'https://www.macrosight.net')"
+    echo "   ❌ INCORRECT (should be 'https://macrosight.net')"
     echo "   🔄 Changes may still be propagating..."
 fi
 echo ""
 
 # Test page availability
 echo "📍 Testing page availability..."
-STATUS=$(curl -s -I https://macrosight.netlify.app/embed.html | head -n 1 | awk '{print $2}')
+STATUS=$(curl -s -I https://macrosight.net/embed.html | head -n 1 | awk '{print $2}')
 if [[ "$STATUS" == "200" ]]; then
     echo "   ✅ Pages loading correctly (HTTP 200)"
 else
@@ -63,14 +63,14 @@ echo ""
 
 # Test security headers
 echo "📍 Testing security headers..."
-HSTS=$(get_header "https://macrosight.netlify.app/home.html" "strict-transport-security")
+HSTS=$(get_header "https://macrosight.net/home.html" "strict-transport-security")
 if [[ -n "$HSTS" ]]; then
     echo "   ✅ HSTS enabled: $HSTS"
 else
     echo "   ❌ HSTS missing"
 fi
 
-CSP=$(get_header "https://macrosight.netlify.app/home.html" "content-security-policy")
+CSP=$(get_header "https://macrosight.net/home.html" "content-security-policy")
 if [[ -n "$CSP" ]]; then
     echo "   ✅ CSP enabled: ${CSP:0:50}..."
 else

--- a/src/public/wix-velo-integration.js
+++ b/src/public/wix-velo-integration.js
@@ -1,10 +1,10 @@
 // Wix Velo integration for MacroSight.net - WEB MODULE
 // This module provides the injectHtml function for embedding static content
-// 
+//
 // DEPLOYMENT NOTE: This file works with the postMessage architecture in embed.html
 // - Step 1: Points iframe to embed.html (shows loading spinner)
-// - Step 2: Fetches the target static HTML page from Netlify
-// - Step 3: Posts content via postMessage to embed.html iframe
+// - Step 2: Fetches the target static HTML and CSS from the site
+// - Step 3: Posts `{ type: 'INJECT', html, css }` via postMessage to embed.html iframe
 // - Step 4: embed.html safeInject() validates and displays content
 //
 // SECURITY: Only whitelisted origins can receive postMessages (see embed.html)
@@ -19,51 +19,53 @@ import { fetch } from 'wix-fetch';
  * @param {string} pageName - The page name to load (e.g., 'home', 'about')
  */
 export async function injectHtml(componentId, pageName) {
-    try {
-        // Find the HTML component
-        const htmlComponent = $w(`#${componentId}`);
-        if (!htmlComponent) {
-            console.warn(`Component #${componentId} not found on this page.`);
-            return;
-        }
-        
-        // Set the iframe source to embed.html with loading spinner
-        htmlComponent.src = 'https://www.macrosight.net/embed.html';
-        
-        // Wait for the iframe to load
-        await new Promise(resolve => {
-            const checkIframe = () => {
-                if (htmlComponent.contentWindow) {
-                    resolve();
-                } else {
-                    setTimeout(checkIframe, 100);
-                }
-            };
-            checkIframe();
-        });
-        
-        // Give the iframe a moment to fully initialize
-        await new Promise(resolve => setTimeout(resolve, 500));
-        
-        // Fetch the page content
-        const response = await fetch(`https://www.macrosight.net/${pageName}.html`);
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-        }
-        
-        const htmlContent = await response.text();
-        
-        // Post the content to the iframe
-        const iframe = htmlComponent.contentWindow;
-        iframe.postMessage(htmlContent, 'https://www.macrosight.net');
-        
-    } catch (error) {
-        console.error(`Failed to inject ${pageName}.html into #${componentId}:`, error);
-        
-        // Fallback - try to load embed.html directly
-        const htmlComponent = $w(`#${componentId}`);
-        if (htmlComponent) {
-            htmlComponent.src = `https://www.macrosight.net/embed.html`;
-        }
+  try {
+    // Find the HTML component
+    const htmlComponent = $w(`#${componentId}`);
+    if (!htmlComponent) {
+      console.warn(`Component #${componentId} not found on this page.`);
+      return;
     }
+
+    // Set the iframe source to embed.html with loading spinner
+    htmlComponent.src = 'https://macrosight.net/embed.html';
+
+    // Wait for the iframe to load
+    await new Promise((resolve) => {
+      const checkIframe = () => {
+        if (htmlComponent.contentWindow) {
+          resolve();
+        } else {
+          setTimeout(checkIframe, 100);
+        }
+      };
+      checkIframe();
+    });
+
+    // Give the iframe a moment to fully initialize
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Fetch the page content
+    const [htmlContent, css] = await Promise.all([
+      fetch(`https://macrosight.net/${pageName}.html`).then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.text();
+      }),
+      fetch('https://macrosight.net/styles.css').then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.text();
+      }),
+    ]);
+
+    const iframe = htmlComponent.contentWindow;
+    iframe.postMessage({ type: 'INJECT', html: htmlContent, css }, 'https://macrosight.net');
+  } catch (error) {
+    console.error(`Failed to inject ${pageName}.html into #${componentId}:`, error);
+
+    // Fallback - try to load embed.html directly
+    const htmlComponent = $w(`#${componentId}`);
+    if (htmlComponent) {
+      htmlComponent.src = `https://macrosight.net/embed.html`;
+    }
+  }
 }

--- a/tests/embed-message.test.js
+++ b/tests/embed-message.test.js
@@ -4,6 +4,6 @@ import fs from 'node:fs/promises';
 
 test('embed.html includes message handler', async () => {
   const html = await fs.readFile('public/embed.html', 'utf8');
-  assert(html.includes('addEventListener("message"'), 'missing postMessage listener');
-  assert(html.includes('ALLOWED_ORIGINS'), 'missing origin whitelist');
+  assert(/addEventListener\(\s*['"]message['"]/m.test(html), 'missing postMessage listener');
+  assert(html.includes('ALLOWED_PARENTS'), 'missing origin whitelist');
 });


### PR DESCRIPTION
## Summary
- accept postMessages from Wix origins and inject HTML/CSS via `{type:'INJECT'}`
- permit Wix to frame pages with `frame-ancestors` CSP and remove legacy origin refs
- document new integration workflow and canonical domain usage

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run lint:html` *(fails: 403 Forbidden when fetching html-validate)*
- `npm test`
- `npm run validate:css` *(fails: Missing script "validate:css")*

------
https://chatgpt.com/codex/tasks/task_e_68a265cbb9f08323b0ff3d222d0bedf7

## Summary by Sourcery

Enable structured HTML/CSS injection and expand secure Wix integration by whitelisting parent frames, updating CSP, standardizing the production domain, and refreshing documentation and tests.

New Features:
- Fetch and inject CSS alongside HTML via a structured postMessage `{type:'INJECT', html, css}`
- Whitelist Wix parent frames with wildcarded origins for secure iframe embedding

Enhancements:
- Switch to canonical production domain `macrosight.net` across code, docs, and test scripts
- Remove legacy X-Frame-Options header and add CSP `frame-ancestors` for Wix in Netlify config
- Refactor embed.html message handler to use an `ALLOWED_PARENTS` set and destructured `safeInject`

Deployment:
- Update netlify.toml to configure CSP `frame-ancestors` for Wix and drop `X-Frame-Options`

Documentation:
- Update README to document the new integration workflow, domain changes, and expanded allowed origins

Tests:
- Revise embed-message.test.js and shell test scripts to validate the new domain and origin whitelist