### PR TITLE
Fix Netlify install failure and secure embed initialization

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+audit=false
+fund=false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 .wix/
 archive/
+node_modules
+dist
+.netlify

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Learn more about [this repo's file structure](https://support.wix.com/en/article
 
 ## Test your code with the Local Editor
 
-The Local Editor allows you test changes made to your site in real time. The code in your local IDE is synced with the Local Editor, so you can test your changes before committing them to your repo. You can also change the site design in the Local Editor and sync it with your IDE.
+The Local Editor allows you to test changes made to your site in real time. The code in your local IDE is synced with the Local Editor, so you can test your changes before committing them to your repo. You can also change the site design in the Local Editor and sync it with your IDE.
 
 Start the Local Editor by navigating to this repo's directory in your terminal and running `wix dev`.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,10 @@
 [build]
   publish = "public"
-  command = ""
+  command = "if [ -f package-lock.json ]; then npm ci; else npm install; fi && npm run build"
+
+[build.environment]
+  NODE_VERSION = "20.19.4"
+  NPM_FLAGS = "--quiet --no-audit --no-fund"
 
 # 🔒 Secure and CORS-Compatible Headers
 

--- a/package.json
+++ b/package.json
@@ -14,22 +14,24 @@
     "coverage": "node scripts/run-playwright.mjs --coverage",
     "validate:links": "node scripts/validate-links.mjs",
     "test:a11y": "node scripts/test-a11y.mjs",
-    "deprecations": "npm deprecations",
     "find-deadcode": "knip",
     "prepare": "husky install",
     "format": "prettier -w ."
   },
   "engines": {
-    "node": "20.x"
+    "node": "20.19.4"
   },
   "devDependencies": {
     "eslint": "^9.33.0",
     "knip": "^3.0.0",
-    "npm-deprecations": "^1.3.0",
     "prettier": "^3.2.5"
+  },
+  "overrides": {
+    "npm-deprecations": "npm:@jsdevtools/rehype-noop@1.0.0"
   },
   "optionalDependencies": {
     "@playwright/test": "^1.44.0",
     "html-validate": "^9.4.0"
-  }
+  },
+  "packageManager": "npm@10.8.2"
 }

--- a/public/embed.html
+++ b/public/embed.html
@@ -48,26 +48,29 @@
     </div>
     <script>
       // Hardened postMessage injection for Wix Velo
-      const ALLOWED_PARENTS = new Set([
+      const ALLOWED_PARENTS = [
         'https://www.wix.com',
         'https://*.wix.com',
         'https://*.wixsite.com',
         'https://editor.wix.com',
         'https://editor.wixstudio.com',
         'https://manage.wix.com',
-      ]);
+      ];
 
       // Test-only: allow local origins to simulate Wix in CI
       try {
         if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {
-          ALLOWED_PARENTS.add(window.location.origin);
+          ALLOWED_PARENTS.push(window.location.origin);
         }
       } catch {}
 
+      function patternToRegex(pattern) {
+        const escaped = pattern.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&').replace(/\\\*/g, '[^.]+');
+        return new RegExp(`^${escaped}$`);
+      }
+
       function isAllowedOrigin(origin) {
-        return [...ALLOWED_PARENTS].some((p) =>
-          new RegExp('^' + p.replace(/\*/g, '.*') + '$').test(origin)
-        );
+        return ALLOWED_PARENTS.some((p) => patternToRegex(p).test(origin));
       }
 
       function safeInject({ html, css }) {

--- a/src/config/origins.js
+++ b/src/config/origins.js
@@ -1,0 +1,25 @@
+export const BASE_ORIGIN = 'https://macrosight.net';
+
+export const ALLOWED_ORIGIN_PATTERNS = [
+  'https://www.wix.com',
+  'https://*.wix.com',
+  'https://*.wixsite.com',
+  'https://editor.wix.com',
+  'https://editor.wixstudio.com',
+  'https://manage.wix.com',
+];
+
+export function patternToRegex(pattern) {
+  const escaped = pattern.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&').replace(/\\\*/g, '[^.]+');
+  return new RegExp(`^${escaped}$`);
+}
+
+export function isAllowedOrigin(origin, patterns = ALLOWED_ORIGIN_PATTERNS) {
+  try {
+    const url = new URL(origin);
+    const normalized = `${url.protocol}//${url.host}`;
+    return patterns.some((p) => patternToRegex(p).test(normalized));
+  } catch {
+    return false;
+  }
+}

--- a/src/public/injectHtml.js
+++ b/src/public/injectHtml.js
@@ -1,8 +1,6 @@
 // @ts-nocheck
 import { fetch } from 'wix-fetch';
-
-// ✅ Use production domain with valid CORS headers
-const base = 'https://macrosight.net';
+import { BASE_ORIGIN } from '../config/origins.js';
 
 /**
  * Injects HTML from Netlify into a Wix HTML Component with loader and error fallback.
@@ -21,11 +19,11 @@ export function injectHtml(componentId, fileSlug, loadingMsg = 'Loading...') {
   $comp.postMessage(`<div style="padding:2em;text-align:center;color:#888;">${loadingMsg}</div>`);
 
   Promise.all([
-    fetch(`${base}/${fileSlug}.html`).then((res) => {
+    fetch(`${BASE_ORIGIN}/${fileSlug}.html`).then((res) => {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return res.text();
     }),
-    fetch(`${base}/styles.css`).then((res) => {
+    fetch(`${BASE_ORIGIN}/styles.css`).then((res) => {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return res.text();
     }),

--- a/src/public/waitForIframe.js
+++ b/src/public/waitForIframe.js
@@ -1,0 +1,26 @@
+export function waitForIframe(iframe, { timeoutMs = 10000 } = {}) {
+  return new Promise((resolve, reject) => {
+    if (!iframe) {
+      reject(new Error('Iframe element not found'));
+      return;
+    }
+
+    const onLoad = () => {
+      clearTimeout(timer);
+      iframe.removeEventListener('load', onLoad);
+      resolve(iframe.contentWindow);
+    };
+
+    const timer = setTimeout(() => {
+      iframe.removeEventListener('load', onLoad);
+      reject(new Error('Iframe did not load within timeout'));
+    }, timeoutMs);
+
+    iframe.addEventListener('load', onLoad, { once: true });
+
+    // If iframe already loaded (cached)
+    if (iframe.contentWindow && iframe.complete) {
+      onLoad();
+    }
+  });
+}

--- a/tests/iframe.test.js
+++ b/tests/iframe.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { waitForIframe } from '../src/public/waitForIframe.js';
+
+function createStubIframe() {
+  const handlers = {};
+  return {
+    contentWindow: {},
+    complete: false,
+    addEventListener(event, cb) {
+      handlers[event] = cb;
+    },
+    removeEventListener(event) {
+      delete handlers[event];
+    },
+    trigger(event) {
+      if (handlers[event]) handlers[event]();
+    },
+  };
+}
+
+test('waitForIframe resolves on load', async () => {
+  const iframe = createStubIframe();
+  const promise = waitForIframe(iframe, { timeoutMs: 50 });
+  setTimeout(() => {
+    iframe.complete = true;
+    iframe.trigger('load');
+  }, 10);
+  assert.equal(await promise, iframe.contentWindow);
+});
+
+test('waitForIframe rejects on timeout', async () => {
+  const iframe = createStubIframe();
+  await assert.rejects(() => waitForIframe(iframe, { timeoutMs: 10 }), /timeout/);
+});

--- a/tests/origins.test.js
+++ b/tests/origins.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { patternToRegex, isAllowedOrigin } from '../src/config/origins.js';
+
+test('patternToRegex handles wildcard and escapes dots', () => {
+  const r = patternToRegex('https://*.macrosight.net');
+  assert.ok(r.test('https://sub.macrosight.net'));
+  assert.ok(!r.test('https://a.b.macrosight.net'));
+  assert.ok(!r.test('https://macrosight.net'));
+});
+
+test('isAllowedOrigin matches allowed origins only', () => {
+  assert.ok(isAllowedOrigin('https://www.wix.com'));
+  assert.ok(isAllowedOrigin('https://sub.wixsite.com'));
+  assert.ok(!isAllowedOrigin('https://evilwix.com'));
+});


### PR DESCRIPTION
## Summary
- pin Node/npm settings for Netlify and add root `.npmrc` to enforce the public registry
- escape wildcard origins and share base domain constant for Wix integrations
- add `waitForIframe` helper and tests for origin matching and iframe load timeout

## Testing
- `npm run test:unit`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prettier-plugin-sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a26a05e0c083238f39dc74f8892977

## Summary by Sourcery

Pin build environment and registry settings for Netlify, centralize BASE_ORIGIN, enhance secure embed initialization with a waitForIframe helper and wildcard origin matching, and add unit tests for iframe loading and origin validation.

New Features:
- Add waitForIframe helper to await iframe load with timeout.

Bug Fixes:
- Pin Node and npm versions and enforce public registry to resolve Netlify install failures.

Enhancements:
- Centralize BASE_ORIGIN constant and replace hardcoded URLs in embed and inject functions.
- Harden postMessage origin validation by converting wildcard patterns to regex in isAllowedOrigin.

Build:
- Update netlify.toml build command and environment variables, set Node engine and npm flags in package.json, and add root .npmrc to enforce the public registry.

Documentation:
- Fix typo in README regarding Local Editor usage.

Tests:
- Add unit tests for iframe load success and timeout, and allowed origin pattern matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved reliability of embedded content by waiting for iframe readiness with a timeout.
  - Safer, more precise origin allowlist matching to prevent false positives.
  - Consistent use of a single base origin for fetching assets.

- Chores
  - Netlify build now installs dependencies and sets Node/NPM versions with quiet flags.
  - Added npm configuration for official registry and disabled audit/funding prompts.
  - Pinned Node version, declared package manager, removed unused scripts/dependencies.
  - Expanded Prettier ignore list.

- Tests
  - Added coverage for iframe loading and origin validation.

- Documentation
  - Minor README formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->