### PR TITLE
Improve mobile navigation accessibility

### DIFF
--- a/public/header.html
+++ b/public/header.html
@@ -27,6 +27,7 @@
 
   <!-- Mobile menu panel -->
   <div class="mobile-nav" id="mobile-nav" hidden role="dialog" aria-modal="true">
+    <button class="close-nav" type="button" aria-label="Close navigation">&times;</button>
     <nav aria-label="Mobile Primary">
       <a href="/home">Home</a>
       <a href="/about">About</a>

--- a/public/mobile-nav.js
+++ b/public/mobile-nav.js
@@ -3,11 +3,26 @@
   function qs(sel) { return document.querySelector(sel); }
 
   function setupMenu() {
-    const btn   = qs('#menu-toggle');
+    const btn = qs('#menu-toggle');
     const panel = qs('#mobile-nav');
-    if (!btn || !panel) return;
+    const close = panel ? panel.querySelector('.close-nav') : null;
+    if (!btn || !panel || !close) return;
 
     let open = false;
+
+    function trapFocus(e) {
+      if (!open || e.key !== 'Tab') return;
+      const focusables = panel.querySelectorAll('a, button');
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
 
     function setState(next) {
       open = next;
@@ -27,17 +42,23 @@
       document.body.style.overflow = open ? 'hidden' : '';
       document.body.style.touchAction = open ? 'none' : '';
 
-      // Keep focus on toggle for accessibility
-      btn.focus();
+      if (open) {
+        close.focus();
+      } else {
+        btn.focus();
+      }
     }
 
-    // Close on link click inside panel
+    // Close on link click or overlay click inside panel
     panel.addEventListener('click', (e) => {
       const link = e.target.closest('a');
-      if (link) setState(false);
+      if (link || e.target === panel) setState(false);
     });
 
+    panel.addEventListener('keydown', trapFocus);
+
     btn.addEventListener('click', () => setState(!open));
+    close.addEventListener('click', () => setState(false));
     document.addEventListener('keydown', (e) => {
       if (open && e.key === 'Escape') setState(false);
     });


### PR DESCRIPTION
## What
- 

## Why
- 

## Validation
- [ ] CI green (lint, links, a11y, e2e)
- [ ] Preview renders with CSS

## Screenshots

## Summary by Sourcery

Improve mobile navigation accessibility by adding a dedicated close button, trapping focus within the panel, and enabling overlay click to close the menu.

Enhancements:
- Add a close button with aria-label to the mobile navigation markup
- Implement focus trapping within the mobile navigation panel when open
- Move focus to the close button on open and restore it to the toggle button on close
- Allow closing the navigation by clicking on the overlay or the close button