### PR TITLE
Add placeholder build script for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "macrosight-site",
   "version": "2.0.0",
   "scripts": {
+    "build": "echo 'No build step required'",
     "dev": "node scripts/serve.mjs",
     "start": "node scripts/serve.mjs",
     "lint": "eslint . --ext .js,.mjs,.ts --max-warnings=0",


### PR DESCRIPTION
## Summary
- define a `build` script so Netlify's build command can succeed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a273adbfe0832382257c306bed3ed8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a standard build script to align tooling and workflows. Running the build command now completes successfully and prints a confirmation message, enabling consistent CI and local developer experience even when no build step is needed. No application behavior or dependencies changed. Prevents script-not-found errors in automation; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->