### PR TITLE
Adjust mobile nav spacing and desktop header alignment

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -239,7 +239,7 @@ nav {
   display: flex;
   gap: 2rem;
   align-items: center;
-  margin-top: 1rem;
+  margin-top: 0;
 }
 
 .mobile-nav nav {
@@ -1538,6 +1538,10 @@ html.menu-open {
     right: 0;
     bottom: 0;
     overflow-y: auto;
+  }
+
+  .nav a {
+    padding: 0.75rem 1.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove extra top margin from navigation to align the desktop header and free up mobile space
- Slightly increase padding on mobile menu links for better tap targets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a282ee7568832393a43c6b2edf5324

## Summary by Sourcery

Adjust navigation spacing by removing the desktop header margin and enhancing mobile menu link padding for improved alignment and usability

Enhancements:
- Remove extra top margin from nav to align desktop header and free up mobile space
- Increase padding on mobile nav links for better tap targets