### PR TITLE
feat: expand mobile menu to full screen

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1577,11 +1577,11 @@ html.menu-open {
 @media (max-width: 899px) {
   #primary-nav {
     position: fixed;
-    top: var(--header-height);
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
+    padding-top: var(--header-height);
     overflow-y: auto;
+    background: var(--header-bg-scrolled);
+    z-index: 50;
   }
 
   .nav a {


### PR DESCRIPTION
## Summary
- expand mobile navigation into full-screen overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28bedcca48323bebfc60abcde79df

## Summary by Sourcery

Expand mobile navigation into a full-screen overlay on small screens

New Features:
- Replace mobile menu positioning with a full-screen overlay

Enhancements:
- Use CSS inset shorthand and top padding for header height
- Add background color and z-index to the mobile navigation overlay