### PR TITLE
refine mobile dropdown menu

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -364,7 +364,10 @@ header {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  padding: 1rem;
+  padding: calc(env(safe-area-inset-top, 0) + 1rem)
+    calc(env(safe-area-inset-right, 0) + 1rem)
+    calc(env(safe-area-inset-bottom, 0) + 1rem)
+    calc(env(safe-area-inset-left, 0) + 1rem);
 }
 
 .mobile-nav .close-nav {


### PR DESCRIPTION
## Summary
- convert full screen mobile overlay into a compact dropdown panel
- constrain mobile nav width and style as card with border and shadow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28f08cee8832393df28671cb2a40a

## Summary by Sourcery

Refine the mobile navigation by converting it from a full-screen overlay into a compact, card-styled dropdown panel under the header.

Enhancements:
- Convert mobile nav from fixed, full-screen overlay to an absolute-positioned dropdown under the header
- Constrain nav width and apply card-style background, border, radius, and box-shadow
- Adjust padding, alignment, and safe-area insets for consistent layout
- Reduce close button bottom margin for tighter spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redesigned mobile navigation from a full-screen overlay to a compact dropdown panel beneath the header.
  - Keeps page content visible while the menu is open for easier context and quicker access.
  - Introduces a card-style look with improved spacing and readability for menu items.
  - Enhances usability on small screens with a more lightweight, less intrusive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->