### PR TITLE
Handle nav overlay link navigation

### DIFF
--- a/public/nav.js
+++ b/public/nav.js
@@ -82,8 +82,18 @@
   });
 
   overlay.addEventListener('click', (e) => {
-    if (e.target === overlay || e.target.tagName === 'A') {
+    if (e.target === overlay) {
       closeMenu();
+    } else if (e.target.tagName === 'A') {
+      const href = e.target.getAttribute('href');
+      if (
+        href &&
+        !href.startsWith('#') &&
+        ((href.startsWith('http') && href !== window.location.href) ||
+          (!href.startsWith('http') && href !== window.location.pathname))
+      ) {
+        closeMenu();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- refine nav overlay behavior: only close menu when overlay itself or a link navigating away is clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a29f205bb88323b2fe93e1c0865e13

## Summary by Sourcery

Enhancements:
- Only close the nav overlay when clicking on the overlay itself or on links that navigate away from the current page, ignoring in-page anchors and same-page links.