### PR TITLE
Use Taylor headshot image

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -25,7 +25,7 @@
     <meta property="og:url" content="https://macrosight.net/about" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -38,7 +38,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {

--- a/public/contact.html
+++ b/public/contact.html
@@ -25,7 +25,7 @@
     <meta property="og:url" content="https://macrosight.net/contact" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -38,7 +38,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {

--- a/public/experience.html
+++ b/public/experience.html
@@ -23,7 +23,7 @@
     <meta property="og:url" content="https://macrosight.net/experience" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -36,7 +36,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {

--- a/public/img/README.md
+++ b/public/img/README.md
@@ -2,9 +2,9 @@ This directory stores images served by the site.
 
 ### Headshot
 
-- `headshot.jpg`: Standard resolution (e.g., 400x400)
-- `headshot@2x.jpg`: Double-resolution version for high-DPI displays
-- `headshot.webp`: Optional WebP version for modern browsers
-- `headshot@2x.webp`: Optional double-resolution WebP
+- `Taylor_headshot.jpg`: Standard resolution (e.g., 400x400)
+- `Taylor_headshot@2x.jpg`: Double-resolution version for high-DPI displays
+- `Taylor_headshot.webp`: Optional WebP version for modern browsers
+- `Taylor_headshot@2x.webp`: Optional double-resolution WebP
 
 Upload your headshot files with these exact names to ensure the home page's `<picture>` element embeds them correctly. Additional images can also be added here and referenced in pages via `/img/<filename>` paths.

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
     <meta property="og:url" content="https://macrosight.net/" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -36,7 +36,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {
@@ -44,7 +44,7 @@
         "@type": "Person",
         "name": "Taylor Dean",
         "url": "https://macrosight.net/",
-        "image": "https://macrosight.net/img/headshot.jpg"
+        "image": "https://macrosight.net/img/Taylor_headshot.jpg"
       }
     </script>
     <link rel="canonical" href="https://macrosight.net/" />
@@ -69,7 +69,7 @@
         <div class="hero-section">
           <picture class="avatar">
             <img
-              src="img/headshot.jpg"
+              src="img/Taylor_headshot.jpg"
               alt="Portrait of Taylor Dean"
               width="320"
               height="320"

--- a/public/invest.html
+++ b/public/invest.html
@@ -20,7 +20,7 @@
     <meta property="og:url" content="https://macrosight.net/invest" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Invest – Taylor Dean | MacroSight" />
@@ -30,7 +30,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {

--- a/public/projects.html
+++ b/public/projects.html
@@ -23,7 +23,7 @@
     <meta property="og:url" content="https://macrosight.net/projects" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -36,7 +36,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {

--- a/public/resume.html
+++ b/public/resume.html
@@ -25,7 +25,7 @@
     <meta property="og:url" content="https://macrosight.net/resume" />
     <meta
       property="og:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -38,7 +38,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://macrosight.net/img/headshot.jpg"
+      content="https://macrosight.net/img/Taylor_headshot.jpg"
     />
     <script type="application/ld+json">
       {


### PR DESCRIPTION
## Summary
- Replace legacy headshot.jpg references with Taylor_headshot.jpg across all pages
- Update image README to document new headshot file names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51d1e01608323a6c51ad10e78df72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the site’s primary headshot used in the hero and profile areas.
  - Refreshed social preview images (Open Graph and Twitter) across key pages for consistent branding.
- Documentation
  - Revised image asset references and guidance to reflect the new headshot variants (JPG/WebP, standard and @2x).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->