### PR TITLE
Fix projects page asset paths, CSP, and header routing

### DIFF
--- a/public/nav.js
+++ b/public/nav.js
@@ -64,13 +64,15 @@
   const header = document.querySelector('.site-header');
   if (!toggle || !overlay) return;
 
-  let path = window.location.pathname.replace(/\/$/, '');
-  if (!path || path === '/') path = '/index.html';
+  let path = window.location.pathname;
+  if (path.endsWith('/')) path += 'index.html';
+  else if (!path.split('/').pop().includes('.')) path += '.html';
   document
     .querySelectorAll('#primary-nav a, [data-menu-overlay] a')
     .forEach((link) => {
-      const linkPath = new URL(link.getAttribute('href'), window.location)
-        .pathname.replace(/\/$/, '');
+      let linkPath = new URL(link.getAttribute('href'), window.location).pathname;
+      if (linkPath.endsWith('/')) linkPath += 'index.html';
+      else if (!linkPath.split('/').pop().includes('.')) linkPath += '.html';
       if (linkPath === path) link.classList.add('active');
     });
 

--- a/public/projects.css
+++ b/public/projects.css
@@ -1,42 +1,40 @@
 :root{
-  --maxw: 1100px;
-  --pad: 1rem;
-  --radius: 12px;
-  --shadow: 0 4px 20px rgba(0,0,0,.08);
-  --chip: 9999px;
-  --gap: 1rem;
-  --muted: #666;
+  --maxw:1100px;
+  --pad:1rem;
+  --radius:12px;
+  --chip:9999px;
+  --gap:1rem;
 }
 *{box-sizing:border-box}
 body{margin:0;font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}
 .container{max-width:var(--maxw);margin:0 auto;padding:calc(var(--pad)*1.5) var(--pad)}
 .page-header h1{margin:0 0 .25rem}
-.lede{color:var(--muted);margin:.25rem 0 1rem}
+.lede{color:var(--color-muted);margin:.25rem 0 1rem}
 
-.segments{display:inline-flex;gap:.25rem;border:1px solid #ddd;border-radius:var(--chip);padding:.25rem;background:#fafafa}
+.segments{display:inline-flex;gap:.25rem;border:1px solid var(--color-border);border-radius:var(--chip);padding:.25rem;background:var(--color-surface)}
 .segment{border:0;background:transparent;padding:.5rem .9rem;border-radius:var(--chip);cursor:pointer}
-.segment.is-active{background:#fff;box-shadow:var(--shadow)}
+.segment.is-active{background:var(--color-card);box-shadow:var(--shadow)}
 .segment:focus-visible{outline:2px solid;outline-offset:2px}
 
 .filters{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;margin:1rem 0}
 .pillars,.tags{display:flex;flex-wrap:wrap;gap:.5rem}
-.chip{border:1px solid #ddd;border-radius:var(--chip);padding:.35rem .7rem;background:#fff;cursor:pointer}
+.chip{border:1px solid var(--color-border);border-radius:var(--chip);padding:.35rem .7rem;background:var(--color-card);cursor:pointer}
 .chip[aria-pressed="true"]{box-shadow:var(--shadow)}
 .search{margin-left:auto}
-.search input{padding:.55rem .75rem;border:1px solid #ddd;border-radius:8px;min-width:220px}
+.search input{padding:.55rem .75rem;border:1px solid var(--color-border);border-radius:8px;min-width:220px;background:var(--color-surface);color:var(--color-fg)}
 
-.meta{color:var(--muted);margin:.5rem 0}
+.meta{color:var(--color-muted);margin:.5rem 0}
 
 .grid{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fill,minmax(260px,1fr));margin-top:.5rem}
-.card{background:#fff;border:1px solid #eee;border-radius:var(--radius);box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:hidden}
-.card .thumb{aspect-ratio:16/9;background:#f4f4f4}
+.card{background:var(--color-card);border:1px solid var(--color-border);border-radius:var(--radius);box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:hidden}
+.card .thumb{aspect-ratio:16/9;background:var(--color-surface)}
 .card .thumb img{width:100%;height:100%;object-fit:cover;display:block}
 .card .body{padding:1rem;display:flex;flex-direction:column;gap:.5rem}
 .card h3{margin:.1rem 0;font-size:1.05rem}
-.card p{margin:0;color:#333}
-.card .meta-row{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;color:var(--muted);font-size:.9rem}
-.badge{border:1px solid #ddd;border-radius:var(--chip);padding:.2rem .5rem}
+.card p{margin:0}
+.card .meta-row{display:flex;flex-wrap:wrap;gap:.5rem;align-items:center;color:var(--color-muted);font-size:.9rem}
+.badge{border:1px solid var(--color-border);border-radius:var(--chip);padding:.2rem .5rem}
 .actions{margin-top:auto;display:flex;gap:.5rem;padding:0 1rem 1rem}
-.actions a{flex:1;text-align:center;text-decoration:none;border:1px solid #ddd;border-radius:8px;padding:.5rem .75rem}
-.actions a:hover{background:#fafafa}
+.actions a{flex:1;text-align:center;text-decoration:none;border:1px solid var(--color-border);border-radius:8px;padding:.5rem .75rem;background:var(--color-card);color:var(--color-fg)}
+.actions a:hover{background:var(--color-surface)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}

--- a/public/projects.html
+++ b/public/projects.html
@@ -4,13 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Projects – MacroSight</title>
-  <link rel="preload" href="/public/data/projects.json" as="fetch" crossorigin="anonymous">
-  <link rel="stylesheet" href="/public/projects.css" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'" />
+  <link rel="preload" href="data/projects.json" as="fetch" crossorigin="anonymous" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="projects.css" />
 </head>
 <body>
   <div id="header-placeholder"></div>
 
-  <main class="container">
+  <main id="main" class="container">
     <header class="page-header">
       <h1>Projects</h1>
       <p class="lede">Engineering work across cloud, HPC, and automation. Toggle demos vs. the broader library, filter by pillars/tags, or search.</p>
@@ -40,7 +42,7 @@
     <section id="projects-grid" class="grid" aria-live="polite"></section>
   </main>
 
-  <script src="/public/projects.js" type="module"></script>
-  <script src="/public/nav.js"></script>
+  <script src="projects.js" type="module"></script>
+  <script src="nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use relative asset paths and add CSP on Projects page
- improve nav active-link matching for pretty URLs
- render project cards securely and handle fetch errors
- switch project styles to CSS variables for dark theme
- harden link detection and render filters via DOM APIs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a646d8a3f083239c661f00e3a7683a