### PR TITLE
Improve tag and pillar contrast

### DIFF
--- a/public/projects.css
+++ b/public/projects.css
@@ -20,7 +20,7 @@ body{margin:0;font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}
 
 .filters{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;margin:1rem 0}
 .pillars,.tags{display:flex;flex-wrap:wrap;gap:.5rem}
-.chip{border:1px solid var(--color-border);border-radius:var(--chip);padding:.35rem .7rem;background:var(--color-card);cursor:pointer;transition:background .15s,color .15s,border-color .15s}
+.chip{border:1px solid var(--color-border);border-radius:var(--chip);padding:.35rem .7rem;background:var(--color-card);color:var(--color-fg);cursor:pointer;transition:background .15s,color .15s,border-color .15s}
 .chip:hover{background:var(--color-surface)}
 .chip[aria-pressed="true"]{background:var(--color-accent);border-color:var(--color-accent-dark);color:var(--color-bg);box-shadow:var(--shadow)}
 .chip[aria-pressed="true"]:hover{background:var(--color-accent-dark)}


### PR DESCRIPTION
## Summary
- ensure tag and pillar chips use foreground text color for better contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a657c274d48323b549824c4cdf0417