### PR TITLE
Add Langflow configuration scaffold and dev server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,36 @@
 
 Simple static website built with vanilla HTML, CSS, and JavaScript.
 
+## Setup
+
+1. Install dependencies (Langflow HTTP client helper and the static server):
+
+   ```bash
+   npm install
+   ```
+
+2. Configure the Langflow endpoint the site should call by editing `public/langflow-config.js`:
+
+   - `baseUrl`: Base URL where your Langflow instance is reachable (e.g., `http://localhost:7860`).
+   - `flowId`: The flow ID you want to run.
+   - `apiPath`: Path prefix for the run endpoint (defaults to `/api/v1/run`).
+   - `defaultHeaders`: Public-only headers to send with each request. Do **not** place API keys or secrets here; if you must add a key, keep it server-side or inject it at build time from an environment file that is not committed (for example, via your hosting platform's build-time environment variables).
+
+   The file ships with placeholder values so you can drop in your own configuration without touching the rest of the codebase.
+
+3. Start a local dev server:
+
+   ```bash
+   npm start
+   ```
+
+   This serves the `public/` directory at `http://localhost:4173`.
+
+4. Optional: If your deployment process supports `.env` files or build-time substitution, you can map `LANGFLOW_BASE_URL`, `LANGFLOW_FLOW_ID`, and related settings into `public/langflow-config.js` during your build step instead of committing live endpoints.
+
 ## Usage
 
-Open `public/index.html` directly in your browser or serve the `public/` directory with any static file server.
+Open `public/index.html` directly in your browser or serve the `public/` directory with any static file server. Use `npm start` during development to serve the site and test Langflow connectivity locally.
 
 ## Mobile navigation
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple static website built with vanilla HTML, CSS, and JavaScript.",
   "main": "index.js",
   "scripts": {
+    "start": "http-server public -p 4173 -c-1",
     "test": "echo \"No tests specified\""
   },
   "keywords": [],
@@ -12,5 +13,8 @@
   "type": "commonjs",
   "devDependencies": {
     "http-server": "^14.1.1"
+  },
+  "dependencies": {
+    "axios": "^1.7.4"
   }
 }

--- a/public/langflow-config.js
+++ b/public/langflow-config.js
@@ -1,0 +1,29 @@
+/**
+ * Public configuration for connecting the site to a Langflow deployment.
+ * Only include values that are safe to expose on the client.
+ */
+window.langflowConfig = {
+  /**
+   * Base URL of the Langflow deployment that exposes the REST API.
+   * Example: "http://localhost:7860" or a hosted URL.
+   */
+  baseUrl: "https://your-langflow-host",
+
+  /**
+   * ID of the flow to execute. This is included in REST calls to Langflow.
+   */
+  flowId: "replace-with-flow-id",
+
+  /**
+   * Optional path prefix for the run endpoint if your deployment uses one.
+   */
+  apiPath: "/api/v1/run",
+
+  /**
+   * Public headers to send with each request. Do NOT place secrets here; use
+   * server-side middleware if you need to sign requests with an API token.
+   */
+  defaultHeaders: {
+    "Content-Type": "application/json"
+  }
+};


### PR DESCRIPTION
## Summary
- add axios dependency and a start script for serving the static site locally
- introduce a public Langflow configuration file for base URL, flow ID, and headers
- document Langflow setup, configuration, and development workflow in the README

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540461a7688323af6480bc8746bb80)

## Summary by Sourcery

Add configurable Langflow client settings and local dev server support for the static site.

New Features:
- Introduce a public Langflow configuration file to define base URL, flow ID, API path, and default headers for client requests.

Enhancements:
- Document Langflow setup, configuration, and development workflow in the README, including environment variable guidance.
- Update usage instructions to recommend using the npm dev server when testing Langflow connectivity locally.

Build:
- Add a start script using http-server to serve the public directory locally and add axios as a runtime dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup section with installation steps, configuration guidance, and local development instructions
  * Updated usage section with recommended development workflow for local testing and connectivity

* **Dependencies**
  * Added HTTP client library for API communication

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->